### PR TITLE
feat(frontend): модалки входа / регистрации / сброса пароля (@mantine/form)

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -1,3 +1,4 @@
+import { AuthModal } from '@/features/auth'
 import { AppProviders } from './providers/AppProviders'
 import { AppRouter } from './routes/AppRouter'
 
@@ -5,6 +6,7 @@ export function App() {
   return (
     <AppProviders>
       <AppRouter />
+      <AuthModal />
     </AppProviders>
   )
 }

--- a/frontend/src/app/store/index.ts
+++ b/frontend/src/app/store/index.ts
@@ -1,6 +1,7 @@
 import { configureStore } from '@reduxjs/toolkit'
 import { sessionSlice } from '@/entities/session'
 import { postsFilterSlice } from '@/features/filter-posts-by-status'
+import { authModalSlice } from '@/features/auth'
 
 /**
  * Redux Toolkit store — holds ONLY client/UI state (session, filters).
@@ -10,6 +11,7 @@ export const store = configureStore({
   reducer: {
     session: sessionSlice.reducer,
     postsFilter: postsFilterSlice.reducer,
+    authModal: authModalSlice.reducer,
   },
 })
 

--- a/frontend/src/features/auth/index.ts
+++ b/frontend/src/features/auth/index.ts
@@ -1,1 +1,11 @@
+export { AuthModal } from './ui/AuthModal'
 export { LoginButton } from './ui/LoginButton'
+export {
+  authModalSlice,
+  openAuth,
+  closeAuth,
+  setAuthMode,
+  selectAuthModal,
+} from './model/authModalSlice'
+export type { AuthMode, AuthModalState } from './model/authModalSlice'
+export { useAuthModal } from './model/hooks'

--- a/frontend/src/features/auth/model/authModalSlice.ts
+++ b/frontend/src/features/auth/model/authModalSlice.ts
@@ -1,0 +1,35 @@
+import { createSlice } from '@reduxjs/toolkit'
+import type { PayloadAction } from '@reduxjs/toolkit'
+
+/** Режим auth-модалки. Один компонент морфится между тремя состояниями (как в макете). */
+export type AuthMode = 'login' | 'register' | 'reset'
+
+/** UI/клиентское состояние (Redux Toolkit): открыта ли модалка и в каком режиме. */
+export interface AuthModalState {
+  opened: boolean
+  mode: AuthMode
+}
+
+const initialState: AuthModalState = { opened: false, mode: 'login' }
+
+export const authModalSlice = createSlice({
+  name: 'authModal',
+  initialState,
+  reducers: {
+    openAuth(state, action: PayloadAction<AuthMode | undefined>) {
+      state.opened = true
+      state.mode = action.payload ?? 'login'
+    },
+    closeAuth(state) {
+      state.opened = false
+    },
+    setAuthMode(state, action: PayloadAction<AuthMode>) {
+      state.mode = action.payload
+    },
+  },
+})
+
+export const { openAuth, closeAuth, setAuthMode } = authModalSlice.actions
+
+export const selectAuthModal = (state: { authModal: AuthModalState }): AuthModalState =>
+  state.authModal

--- a/frontend/src/features/auth/model/hooks.ts
+++ b/frontend/src/features/auth/model/hooks.ts
@@ -1,0 +1,16 @@
+import { useDispatch, useSelector } from 'react-redux'
+import { closeAuth, openAuth, selectAuthModal, setAuthMode } from './authModalSlice'
+import type { AuthMode } from './authModalSlice'
+
+/** Управление auth-модалкой: открыть в нужном режиме / закрыть / сменить режим. */
+export function useAuthModal() {
+  const dispatch = useDispatch()
+  const { opened, mode } = useSelector(selectAuthModal)
+  return {
+    opened,
+    mode,
+    open: (m?: AuthMode) => dispatch(openAuth(m)),
+    close: () => dispatch(closeAuth()),
+    setMode: (m: AuthMode) => dispatch(setAuthMode(m)),
+  }
+}

--- a/frontend/src/features/auth/ui/AuthModal.tsx
+++ b/frontend/src/features/auth/ui/AuthModal.tsx
@@ -1,0 +1,92 @@
+import { Anchor, Divider, Modal, SegmentedControl, Stack, Text, Title } from '@mantine/core'
+import { useAuthModal } from '../model/hooks'
+import type { AuthMode } from '../model/authModalSlice'
+import { OAuthButtons } from './OAuthButtons'
+import { LoginForm } from './LoginForm'
+import { RegisterForm } from './RegisterForm'
+import { ResetForm } from './ResetForm'
+
+const COPY: Record<AuthMode, { title: string; subtitle: string }> = {
+  login: {
+    title: 'С возвращением!',
+    subtitle: 'Посты уже заждались — войдите и проверьте очередь.',
+  },
+  register: {
+    title: 'Создайте аккаунт',
+    subtitle: 'Бесплатный тариф навсегда: 3 соцсети и 10 постов в месяц. Карта не нужна.',
+  },
+  reset: {
+    title: 'Восстановим пароль',
+    subtitle: 'Укажите почту аккаунта — пришлём ссылку для сброса пароля.',
+  },
+}
+
+/**
+ * Единая auth-модалка: морфится между режимами вход / регистрация / сброс пароля
+ * (как в макете docs/design/mockups/login.html). Открывается через Redux (useAuthModal).
+ */
+export function AuthModal() {
+  const { opened, mode, close, setMode } = useAuthModal()
+  const isAuth = mode !== 'reset'
+
+  return (
+    <Modal opened={opened} onClose={close} centered radius="lg" size="sm" title={null}>
+      <Stack gap="md">
+        <SegmentedControl
+          fullWidth
+          color="dark"
+          value={mode === 'register' ? 'register' : 'login'}
+          onChange={(v) => setMode(v as AuthMode)}
+          data={[
+            { label: 'Вход', value: 'login' },
+            { label: 'Регистрация', value: 'register' },
+          ]}
+        />
+
+        <div>
+          <Title order={3} fz={22} fw={800}>
+            {COPY[mode].title}
+          </Title>
+          <Text c="dimmed" fz={13} mt={4}>
+            {COPY[mode].subtitle}
+          </Text>
+        </div>
+
+        {isAuth && (
+          <>
+            <OAuthButtons />
+            <Divider label="или по почте" labelPosition="center" />
+          </>
+        )}
+
+        {mode === 'login' && <LoginForm />}
+        {mode === 'register' && <RegisterForm />}
+        {mode === 'reset' && <ResetForm />}
+
+        {isAuth ? (
+          <Text ta="center" fz="sm" c="dimmed">
+            {mode === 'register' ? 'Уже есть аккаунт? ' : 'Ещё нет аккаунта? '}
+            <Anchor
+              component="button"
+              type="button"
+              fz="sm"
+              onClick={() => setMode(mode === 'register' ? 'login' : 'register')}
+            >
+              {mode === 'register' ? 'Войти' : 'Зарегистрироваться'}
+            </Anchor>
+          </Text>
+        ) : (
+          <Anchor
+            component="button"
+            type="button"
+            ta="center"
+            fz="sm"
+            onClick={() => setMode('login')}
+          >
+            ← Вернуться ко входу
+          </Anchor>
+        )}
+      </Stack>
+    </Modal>
+  )
+}

--- a/frontend/src/features/auth/ui/LoginForm.tsx
+++ b/frontend/src/features/auth/ui/LoginForm.tsx
@@ -1,0 +1,51 @@
+import { Anchor, Button, Checkbox, Group, PasswordInput, Stack, TextInput } from '@mantine/core'
+import { useForm } from '@mantine/form'
+import { notifications } from '@mantine/notifications'
+import { useAuthModal } from '../model/hooks'
+
+interface LoginValues {
+  email: string
+  password: string
+  remember: boolean
+}
+
+export function LoginForm() {
+  const { close, setMode } = useAuthModal()
+
+  const form = useForm<LoginValues>({
+    initialValues: { email: '', password: '', remember: false },
+    validate: {
+      email: (v) => (/^\S+@\S+\.\S+$/.test(v) ? null : 'Введите корректную почту'),
+      password: (v) => (v.length > 0 ? null : 'Введите пароль'),
+    },
+  })
+
+  const submit = form.onSubmit(() => {
+    // TODO (Design First): POST /auth/login (email + password, remember-me), issue #110. Пока заглушка.
+    notifications.show({ color: 'green', message: 'Вход выполнен (демо)' })
+    close()
+  })
+
+  return (
+    <form onSubmit={submit}>
+      <Stack gap="sm">
+        <TextInput label="Почта" placeholder="you@example.ru" withAsterisk {...form.getInputProps('email')} />
+        <PasswordInput
+          label="Пароль"
+          placeholder="••••••••"
+          withAsterisk
+          {...form.getInputProps('password')}
+        />
+        <Group justify="space-between">
+          <Checkbox label="Запомнить меня" {...form.getInputProps('remember', { type: 'checkbox' })} />
+          <Anchor component="button" type="button" size="sm" onClick={() => setMode('reset')}>
+            Забыли пароль?
+          </Anchor>
+        </Group>
+        <Button type="submit" fullWidth mt={4}>
+          Войти
+        </Button>
+      </Stack>
+    </form>
+  )
+}

--- a/frontend/src/features/auth/ui/OAuthButtons.tsx
+++ b/frontend/src/features/auth/ui/OAuthButtons.tsx
@@ -1,0 +1,34 @@
+import { Button, SimpleGrid } from '@mantine/core'
+import { env } from '@/shared/config'
+
+/** 6 провайдеров OAuth из макета входа, с брендовыми цветами. */
+const PROVIDERS = [
+  { id: 'vk', label: 'VK ID', color: '#0077FF', fg: '#fff' },
+  { id: 'telegram', label: 'Telegram', color: '#27A6E5', fg: '#fff' },
+  { id: 'yandex', label: 'Яндекс', color: '#FC3F1D', fg: '#fff' },
+  { id: 'sber', label: 'Сбер ID', color: '#21A038', fg: '#fff' },
+  { id: 'tinkoff', label: 'T-ID', color: '#FFDD2D', fg: '#17150F' },
+  { id: 'gosuslugi', label: 'Госуслуги', color: '#0D4CD3', fg: '#fff' },
+]
+
+export function OAuthButtons() {
+  return (
+    <SimpleGrid cols={3} spacing="xs">
+      {PROVIDERS.map((p) => (
+        <Button
+          key={p.id}
+          size="sm"
+          radius="md"
+          fw={600}
+          styles={{ root: { background: p.color, color: p.fg } }}
+          onClick={() => {
+            // Design First: реальный OAuth-редирект на бэкенд (/auth/{provider}), см. issue #133/#111.
+            window.location.href = `${env.apiUrl}/auth/${p.id}`
+          }}
+        >
+          {p.label}
+        </Button>
+      ))}
+    </SimpleGrid>
+  )
+}

--- a/frontend/src/features/auth/ui/RegisterForm.tsx
+++ b/frontend/src/features/auth/ui/RegisterForm.tsx
@@ -1,0 +1,64 @@
+import { Anchor, Button, Checkbox, PasswordInput, Stack, TextInput } from '@mantine/core'
+import { useForm } from '@mantine/form'
+import { notifications } from '@mantine/notifications'
+import { useAuthModal } from '../model/hooks'
+
+interface RegisterValues {
+  name: string
+  email: string
+  password: string
+  oferta: boolean
+}
+
+export function RegisterForm() {
+  const { close } = useAuthModal()
+
+  const form = useForm<RegisterValues>({
+    initialValues: { name: '', email: '', password: '', oferta: false },
+    validate: {
+      name: (v) => (v.trim().length > 0 ? null : 'Как к вам обращаться?'),
+      email: (v) => (/^\S+@\S+\.\S+$/.test(v) ? null : 'Введите корректную почту'),
+      password: (v) => (v.length >= 6 ? null : 'Минимум 6 символов'),
+      oferta: (v) => (v ? null : 'Нужно принять условия'),
+    },
+  })
+
+  const submit = form.onSubmit(() => {
+    // TODO (Design First): POST /auth/register + провижининг free-тарифа, issue #110. Пока заглушка.
+    notifications.show({ color: 'green', message: 'Аккаунт создан (демо)' })
+    close()
+  })
+
+  return (
+    <form onSubmit={submit}>
+      <Stack gap="sm">
+        <TextInput label="Как вас зовут" placeholder="Мария" withAsterisk {...form.getInputProps('name')} />
+        <TextInput label="Почта" placeholder="you@example.ru" withAsterisk {...form.getInputProps('email')} />
+        <PasswordInput
+          label="Пароль"
+          placeholder="••••••••"
+          withAsterisk
+          {...form.getInputProps('password')}
+        />
+        <Checkbox
+          {...form.getInputProps('oferta', { type: 'checkbox' })}
+          label={
+            <>
+              Принимаю{' '}
+              <Anchor href="/legal" target="_blank">
+                оферту
+              </Anchor>{' '}
+              и{' '}
+              <Anchor href="/legal" target="_blank">
+                политику конфиденциальности
+              </Anchor>
+            </>
+          }
+        />
+        <Button type="submit" fullWidth mt={4}>
+          Создать аккаунт
+        </Button>
+      </Stack>
+    </form>
+  )
+}

--- a/frontend/src/features/auth/ui/ResetForm.tsx
+++ b/frontend/src/features/auth/ui/ResetForm.tsx
@@ -1,0 +1,48 @@
+import { Alert, Button, Stack, TextInput } from '@mantine/core'
+import { IconMailCheck } from '@tabler/icons-react'
+import { useForm } from '@mantine/form'
+import { useState } from 'react'
+
+interface ResetValues {
+  email: string
+}
+
+export function ResetForm() {
+  const [sent, setSent] = useState(false)
+
+  const form = useForm<ResetValues>({
+    initialValues: { email: '' },
+    validate: {
+      email: (v) => (/^\S+@\S+\.\S+$/.test(v) ? null : 'Введите корректную почту'),
+    },
+  })
+
+  const submit = form.onSubmit(() => {
+    // TODO (Design First): POST /auth/password-reset (email), issue #110. Пока заглушка.
+    setSent(true)
+  })
+
+  if (sent) {
+    return (
+      <Stack gap="sm">
+        <Alert color="green" icon={<IconMailCheck size={18} />} title="Ссылка отправлена.">
+          Проверьте почту — там ссылка для сброса пароля.
+        </Alert>
+        <Button variant="light" fullWidth onClick={() => setSent(false)}>
+          Отправить ещё раз
+        </Button>
+      </Stack>
+    )
+  }
+
+  return (
+    <form onSubmit={submit}>
+      <Stack gap="sm">
+        <TextInput label="Почта" placeholder="you@example.ru" withAsterisk {...form.getInputProps('email')} />
+        <Button type="submit" fullWidth mt={4}>
+          Отправить ссылку
+        </Button>
+      </Stack>
+    </form>
+  )
+}

--- a/frontend/src/widgets/marketing-header/ui/MarketingHeader.tsx
+++ b/frontend/src/widgets/marketing-header/ui/MarketingHeader.tsx
@@ -1,6 +1,7 @@
 import { Anchor, Box, Button, Container, Group } from '@mantine/core'
 import { Link } from 'react-router-dom'
 import { Logo } from '@/shared/ui'
+import { useAuthModal } from '@/features/auth'
 
 const NAV = [
   { label: 'Возможности', href: '#features' },
@@ -12,6 +13,7 @@ const NAV = [
 
 /** Липкая шапка маркетинг-сайта: логотип, якорная навигация, кнопки входа. */
 export function MarketingHeader() {
+  const { open } = useAuthModal()
   return (
     <Box
       component="header"
@@ -46,10 +48,10 @@ export function MarketingHeader() {
             </Group>
           </Group>
           <Group gap="sm" wrap="nowrap">
-            <Button component={Link} to="/login" variant="subtle" color="dark" size="sm" visibleFrom="xs">
+            <Button variant="subtle" color="dark" size="sm" visibleFrom="xs" onClick={() => open('login')}>
               Войти
             </Button>
-            <Button component={Link} to="/login" size="sm">
+            <Button size="sm" onClick={() => open('register')}>
               Попробовать бесплатно
             </Button>
           </Group>


### PR DESCRIPTION
Единая **auth-модалка**, которая морфится между тремя режимами — **вход / регистрация / сброс пароля** — по макету `docs/design/mockups/login.html`. На **Mantine** + **@mantine/form**, в цветах нашей темы.

## Что внутри (`features/auth`, FSD)
- **`AuthModal`** — табы Вход/Регистрация + режим сброса; заголовки/подзаголовки и футер-переключатель дословно из макета.
- **Формы на `@mantine/form`** с валидацией: `LoginForm` (почта, пароль, «Запомнить меня», «Забыли пароль?»), `RegisterForm` (имя, почта, пароль, согласие с офертой), `ResetForm` (почта → «Ссылка отправлена»).
- **`OAuthButtons`** — 6 провайдеров в брендовых цветах: VK ID, Telegram, Яндекс, Сбер ID, T-ID, Госуслуги.
- **UI-состояние модалки** — в Redux (`model/authModalSlice`), открывается из шапки: «Войти» → вход, «Попробовать бесплатно» → регистрация.
- Сабмиты — заглушки с TODO на `/auth/*` (Design First, issue #110/#111).

## Проверено
- `tsc --noEmit` и `vite build` — зелёные.
- Все три режима отрендерены и совпадают с макетом.
- Поправлен баг: `AuthModal` монтируется вне `RouterProvider`, поэтому ссылки оферты сделаны обычным `href` (react-router `Link` вне контекста роутера падал белым экраном).

Закрывает фронтовую часть эпика авторизации (#94).
