### PR TITLE
chore: git-хук — запрет упоминаний Claude/Anthropic в коммитах

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,17 @@
+#!/bin/sh
+# ЖЁСТКИЙ ЗАПРЕТ: удаляем любые упоминания Claude / Anthropic / AI-атрибуции
+# из сообщения коммита. Хук вызывается git'ом на КАЖДОМ коммите.
+# Включается: git config core.hooksPath .githooks
+f="$1"
+tmp="$(mktemp)"
+
+grep -viE 'co-authored-by:.*(claude|anthropic)|noreply@anthropic|generated with .*claude|claude code|claude opus|🤖' "$f" > "$tmp"
+
+# Не затираем сообщение, если после фильтрации что-то осталось.
+if [ -s "$tmp" ]; then
+  mv "$tmp" "$f"
+else
+  rm -f "$tmp"
+fi
+
+exit 0


### PR DESCRIPTION
Жёсткий запрет на AI-атрибуцию в сообщениях коммитов — на уровне git.

## Что делает
`.githooks/commit-msg` авто-вырезает из сообщения любого коммита строки:
- `Co-Authored-By: ... Claude/Anthropic ...`
- `... Generated with ... Claude Code ...`
- `noreply@anthropic.com`, `🤖`

Работает для **любого** инструмента и человека (git вызывает хук на каждом коммите) — надёжнее любых договорённостей.

## Как включить
```bash
git config core.hooksPath .githooks
```
(однократно на каждой машине; можно вынести в `make`-таргет setup).

Проверено: коммит с намеренно вписанным трейлером сохраняется уже без него.
