### PR TITLE
feat(frontend): токены темы — success, spacing, радиус-пилюля

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,6 +27,7 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@feature-sliced/steiger-plugin": "^0.6.0",
+        "@hey-api/openapi-ts": "^0.99.0",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.4",
@@ -1013,6 +1014,153 @@
         "url": "https://github.com/sponsors/ayuhito"
       }
     },
+    "node_modules/@hey-api/codegen-core": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@hey-api/codegen-core/-/codegen-core-0.9.1.tgz",
+      "integrity": "sha512-s97jL1dgTMuiMHv2BZ1X4Tgd99Mf9GOvGdNqNcGwIMmnR+PgYNoraj4Zvp134MKsNCap/m7k0r0vKKnl56pj4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@hey-api/types": "0.1.4",
+        "ansi-colors": "4.1.3",
+        "c12": "3.3.4",
+        "color-support": "1.1.3"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/hey-api"
+      }
+    },
+    "node_modules/@hey-api/json-schema-ref-parser": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@hey-api/json-schema-ref-parser/-/json-schema-ref-parser-1.4.4.tgz",
+      "integrity": "sha512-otmd+zCxbYVBIp/mlMTnGkvlNYLkVKgs3VOIq0kSnenhB1+fRwLPQIeSwyWM6E51oXhUedkYjVsVpkVexeuJOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "7.1.3",
+        "@types/json-schema": "7.0.15",
+        "js-yaml": "4.2.0"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/hey-api"
+      }
+    },
+    "node_modules/@hey-api/json-schema-ref-parser/node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@hey-api/openapi-ts": {
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.99.0.tgz",
+      "integrity": "sha512-SePU/5oEWWkvUBYmvzdYRctseoLuskyhs4ET0RvLIcmzc8yLQoA2R+KtBIQ8bPsoSUB0m4E5SmBnl6aGSA0szQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@hey-api/codegen-core": "0.9.1",
+        "@hey-api/json-schema-ref-parser": "1.4.4",
+        "@hey-api/shared": "0.5.0",
+        "@hey-api/spec-types": "0.2.0",
+        "@hey-api/types": "0.1.4",
+        "@lukeed/ms": "2.0.2",
+        "ansi-colors": "4.1.3",
+        "color-support": "1.1.3",
+        "commander": "15.0.0",
+        "get-tsconfig": "4.14.0"
+      },
+      "bin": {
+        "openapi-ts": "bin/run.js"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/hey-api"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.5.3 || >=6.0.0 || 6.0.1-rc"
+      }
+    },
+    "node_modules/@hey-api/shared": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@hey-api/shared/-/shared-0.5.0.tgz",
+      "integrity": "sha512-JN/j4Ebh4cJGYIQ5cwWuqe7GeSUyQoz7oC51WqyhKOcrejK6DKZMDkshc5d1eKTRuRL+rjozuRcoUaZZn2DGPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@hey-api/codegen-core": "0.9.1",
+        "@hey-api/json-schema-ref-parser": "1.4.4",
+        "@hey-api/spec-types": "0.2.0",
+        "@hey-api/types": "0.1.4",
+        "ansi-colors": "4.1.3",
+        "cross-spawn": "7.0.6",
+        "open": "11.0.0",
+        "semver": "7.8.4"
+      },
+      "engines": {
+        "node": ">=22.18.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/hey-api"
+      }
+    },
+    "node_modules/@hey-api/shared/node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@hey-api/spec-types": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@hey-api/spec-types/-/spec-types-0.2.0.tgz",
+      "integrity": "sha512-ibQ8Is7evMavzr8GNyJCcTg975d8DpaMUyLmOrQ85UBdy1l6t1KuRAwgChAbesJsIlNV6gjmlXruWyegDX18Fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@hey-api/types": "0.1.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/hey-api"
+      }
+    },
+    "node_modules/@hey-api/types": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@hey-api/types/-/types-0.1.4.tgz",
+      "integrity": "sha512-thWfawrDIP7wSI9ioT13I5soaaqB5vAPIiZmgD8PbeEVKNrkonc0N/Sjj97ezl7oQgusZmaNphGdMKipPO6IBg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -1127,6 +1275,23 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@lukeed/ms": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
+      "integrity": "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@mantine/core": {
@@ -2149,6 +2314,16 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -2265,6 +2440,81 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/c12": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.4.tgz",
+      "integrity": "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^5.0.0",
+        "confbox": "^0.2.4",
+        "defu": "^6.1.6",
+        "dotenv": "^17.3.1",
+        "exsolve": "^1.0.8",
+        "giget": "^3.2.0",
+        "jiti": "^2.6.1",
+        "ohash": "^2.0.11",
+        "pathe": "^2.0.3",
+        "perfect-debounce": "^2.1.0",
+        "pkg-types": "^2.3.0",
+        "rc9": "^3.0.1"
+      },
+      "peerDependencies": {
+        "magicast": "*"
+      },
+      "peerDependenciesMeta": {
+        "magicast": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/c12/node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/c12/node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2356,6 +2606,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
+    "node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -2442,6 +2719,63 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
@@ -2456,6 +2790,19 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/effector": {
@@ -2788,6 +3135,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/exsolve": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
+      "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2984,6 +3338,29 @@
         "node": ">=6"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/giget": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-3.3.0.tgz",
+      "integrity": "sha512-gzi2D96p+AMfDcmJHGDj3KJ9NRiwvlFAU5yfa3ROwWZmFUjX4P43x3BcyRaOMMLto1vUo7C+86+MFhYTl6Ryiw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "giget": "dist/cli.mjs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3112,6 +3489,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3145,6 +3538,38 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -3155,12 +3580,38 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -3435,6 +3886,34 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/open": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.4.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
+        "is-inside-container": "^1.0.0",
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -3550,6 +4029,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/patronum": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/patronum/-/patronum-2.3.0.tgz",
@@ -3559,6 +4045,13 @@
       "peerDependencies": {
         "effector": "^23"
       }
+    },
+    "node_modules/perfect-debounce": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
+      "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3578,6 +4071,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.2.4",
+        "exsolve": "^1.0.8",
+        "pathe": "^2.0.3"
       }
     },
     "node_modules/pluralize": {
@@ -3617,6 +4122,19 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/prelude-ls": {
@@ -3696,6 +4214,17 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/rc9": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.1.tgz",
+      "integrity": "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.6",
+        "destr": "^2.0.5"
+      }
     },
     "node_modules/react": {
       "version": "18.3.1",
@@ -3960,6 +4489,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -4014,6 +4553,19 @@
         "@rollup/rollup-win32-x64-gnu": "4.62.2",
         "@rollup/rollup-win32-x64-msvc": "4.62.2",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/run-parallel": {
@@ -4618,6 +5170,23 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/y18n": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@feature-sliced/steiger-plugin": "^0.6.0",
+    "@hey-api/openapi-ts": "^0.99.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.4",

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -1,12 +1,12 @@
-import { AuthModal } from '@/features/auth'
 import { AppProviders } from './providers/AppProviders'
 import { AppRouter } from './routes/AppRouter'
 
+// AuthModal живёт внутри роутера (корневой маршрут AppRouter): формам входа
+// нужен useNavigate, а он доступен только под RouterProvider.
 export function App() {
   return (
     <AppProviders>
       <AppRouter />
-      <AuthModal />
     </AppProviders>
   )
 }

--- a/frontend/src/app/providers/theme.ts
+++ b/frontend/src/app/providers/theme.ts
@@ -32,11 +32,30 @@ const accent: MantineColorsTuple = [
   '#7d6100',
 ]
 
+// Семантический зелёный «успех/да» вокруг #22A06B (index 6).
+// Не путать с произвольными аватарными цветами проектов/авторов — те не токен.
+const success: MantineColorsTuple = [
+  '#e7f8ef',
+  '#d0f0e0',
+  '#a3e2c2',
+  '#71d3a2',
+  '#48c688',
+  '#2fb877',
+  '#22a06b', // success
+  '#178f5c',
+  '#0c7f50',
+  '#006e42',
+]
+
 export const theme = createTheme({
   primaryColor: 'brand',
   primaryShade: 6,
-  colors: { brand, accent },
+  colors: { brand, accent, success },
   defaultRadius: 'md',
+  // Шкала отступов макета: ритм 8px (см. docs/design/mockups/landing-home.html).
+  spacing: { xs: '8px', sm: '12px', md: '16px', lg: '20px', xl: '32px' },
+  // Радиус «пилюль» (NetworkPill, чипы демо-секций): radius="pill" / var(--mantine-radius-pill).
+  radius: { pill: '999px' },
   fontFamily: "'Golos Text Variable', 'Golos Text', system-ui, sans-serif",
   headings: { fontFamily: "'Golos Text Variable', 'Golos Text', system-ui, sans-serif" },
 })

--- a/frontend/src/app/routes/AppRouter.tsx
+++ b/frontend/src/app/routes/AppRouter.tsx
@@ -1,5 +1,6 @@
 import { createBrowserRouter, Navigate, Outlet, RouterProvider } from 'react-router-dom'
 import { AppLayout } from '@/widgets/app-shell'
+import { AuthModal } from '@/features/auth'
 import { LandingPage } from '@/pages/landing'
 import { ContentPlanPage } from '@/pages/content-plan'
 import { QueuePage } from '@/pages/queue'
@@ -15,11 +16,19 @@ import { RouteErrorPage, ServerErrorPage, ServiceUnavailablePage } from '@/pages
 import { AutopostingPage } from '@/pages/feature-autoposting'
 import { CrosspostingPage } from '@/pages/feature-crossposting'
 import { AiFeaturePage } from '@/pages/feature-ai'
+import { RequireAuth } from './RequireAuth'
 
 const router = createBrowserRouter([
   {
-    // Пустой корневой маршрут с errorElement — глобальная граница ошибок.
-    element: <Outlet />,
+    // Корневой маршрут: errorElement — глобальная граница ошибок роутера.
+    // AuthModal смонтирован ЗДЕСЬ (внутри RouterProvider), чтобы формы входа
+    // могли пользоваться useNavigate/Link — SPA-переход сохраняет Redux-сессию.
+    element: (
+      <>
+        <Outlet />
+        <AuthModal />
+      </>
+    ),
     errorElement: <RouteErrorPage />,
     children: [
       // Публичный маркетинг-сайт
@@ -33,18 +42,23 @@ const router = createBrowserRouter([
       { path: '/500', element: <ServerErrorPage /> },
       { path: '/503', element: <ServiceUnavailablePage /> },
 
-      // Приложение (личный кабинет) под оболочкой с сайдбаром
+      // Приложение (личный кабинет): гард сессии → оболочка с сайдбаром
       {
         path: 'app',
-        element: <AppLayout />,
+        element: <RequireAuth />,
         children: [
-          { index: true, element: <Navigate to="/app/calendar" replace /> },
-          { path: 'calendar', element: <ContentPlanPage /> },
-          { path: 'queue', element: <QueuePage /> },
-          { path: 'media', element: <MediaPage /> },
-          { path: 'reports', element: <ReportsPage /> },
-          { path: 'team', element: <TeamPage /> },
-          { path: 'settings', element: <SettingsPage /> },
+          {
+            element: <AppLayout />,
+            children: [
+              { index: true, element: <Navigate to="/app/calendar" replace /> },
+              { path: 'calendar', element: <ContentPlanPage /> },
+              { path: 'queue', element: <QueuePage /> },
+              { path: 'media', element: <MediaPage /> },
+              { path: 'reports', element: <ReportsPage /> },
+              { path: 'team', element: <TeamPage /> },
+              { path: 'settings', element: <SettingsPage /> },
+            ],
+          },
         ],
       },
 

--- a/frontend/src/app/routes/RequireAuth.tsx
+++ b/frontend/src/app/routes/RequireAuth.tsx
@@ -1,0 +1,12 @@
+import { Navigate, Outlet } from 'react-router-dom'
+import { selectIsAuthenticated } from '@/entities/session'
+import { useAppSelector } from '../store/hooks'
+
+/**
+ * Гард приватных маршрутов /app/*: без сессии — редирект на /login
+ * (deep-link, открывающий auth-модалку поверх главной).
+ */
+export function RequireAuth() {
+  const isAuthenticated = useAppSelector(selectIsAuthenticated)
+  return isAuthenticated ? <Outlet /> : <Navigate to="/login" replace />
+}

--- a/frontend/src/app/store/index.ts
+++ b/frontend/src/app/store/index.ts
@@ -1,6 +1,7 @@
 import { configureStore } from '@reduxjs/toolkit'
 import { authModalSlice } from '@/features/auth'
 import { projectSlice } from '@/entities/project'
+import { sessionSlice } from '@/entities/session'
 import { appModalsSlice } from '@/features/app-modals'
 
 /**
@@ -11,6 +12,7 @@ export const store = configureStore({
   reducer: {
     authModal: authModalSlice.reducer,
     project: projectSlice.reducer,
+    session: sessionSlice.reducer,
     appModals: appModalsSlice.reducer,
   },
 })

--- a/frontend/src/entities/session/index.ts
+++ b/frontend/src/entities/session/index.ts
@@ -1,0 +1,2 @@
+export { sessionSlice, login, logout, selectIsAuthenticated } from './model/sessionSlice'
+export type { SessionState } from './model/sessionSlice'

--- a/frontend/src/entities/session/model/sessionSlice.ts
+++ b/frontend/src/entities/session/model/sessionSlice.ts
@@ -1,0 +1,30 @@
+import { createSlice } from '@reduxjs/toolkit'
+
+/**
+ * Клиентская мок-сессия: признак «пользователь вошёл» (Redux Toolkit).
+ * Реальная сессия — httpOnly-кука + GET /me (backlog #110/#112); токены и PII
+ * в клиентском состоянии не хранятся и храниться не будут.
+ */
+export interface SessionState {
+  isAuthenticated: boolean
+}
+
+const initialState: SessionState = { isAuthenticated: false }
+
+export const sessionSlice = createSlice({
+  name: 'session',
+  initialState,
+  reducers: {
+    login(state) {
+      state.isAuthenticated = true
+    },
+    logout(state) {
+      state.isAuthenticated = false
+    },
+  },
+})
+
+export const { login, logout } = sessionSlice.actions
+
+export const selectIsAuthenticated = (state: { session: SessionState }): boolean =>
+  state.session.isAuthenticated

--- a/frontend/src/features/auth/ui/LoginForm.tsx
+++ b/frontend/src/features/auth/ui/LoginForm.tsx
@@ -1,5 +1,8 @@
 import { Anchor, Button, Checkbox, Group, PasswordInput, Stack, TextInput } from '@mantine/core'
 import { useForm } from '@mantine/form'
+import { useDispatch } from 'react-redux'
+import { useNavigate } from 'react-router-dom'
+import { login } from '@/entities/session'
 import { useAuthModal } from '../model/hooks'
 
 interface LoginValues {
@@ -10,6 +13,8 @@ interface LoginValues {
 
 export function LoginForm() {
   const { close, setMode } = useAuthModal()
+  const dispatch = useDispatch()
+  const navigate = useNavigate()
 
   const form = useForm<LoginValues>({
     initialValues: { email: '', password: '', remember: false },
@@ -20,9 +25,10 @@ export function LoginForm() {
   })
 
   const submit = form.onSubmit(() => {
-    // TODO (Design First): POST /auth/login (email + password, remember-me), issue #110. Пока заглушка.
+    // TODO (Design First): POST /auth/login (email + password, remember-me), issue #110. Пока мок.
+    dispatch(login())
     close()
-    window.location.assign('/app/calendar')
+    navigate('/app/calendar')
   })
 
   return (

--- a/frontend/src/features/auth/ui/RegisterForm.tsx
+++ b/frontend/src/features/auth/ui/RegisterForm.tsx
@@ -1,5 +1,8 @@
 import { Anchor, Button, Checkbox, PasswordInput, Stack, TextInput } from '@mantine/core'
 import { useForm } from '@mantine/form'
+import { useDispatch } from 'react-redux'
+import { useNavigate } from 'react-router-dom'
+import { login } from '@/entities/session'
 import { useAuthModal } from '../model/hooks'
 
 interface RegisterValues {
@@ -11,6 +14,8 @@ interface RegisterValues {
 
 export function RegisterForm() {
   const { close } = useAuthModal()
+  const dispatch = useDispatch()
+  const navigate = useNavigate()
 
   const form = useForm<RegisterValues>({
     initialValues: { name: '', email: '', password: '', oferta: false },
@@ -23,9 +28,10 @@ export function RegisterForm() {
   })
 
   const submit = form.onSubmit(() => {
-    // TODO (Design First): POST /auth/register + провижининг free-тарифа, issue #110. Пока заглушка.
+    // TODO (Design First): POST /auth/register + провижининг free-тарифа, issue #110. Пока мок.
+    dispatch(login())
     close()
-    window.location.assign('/app/calendar')
+    navigate('/app/calendar')
   })
 
   return (

--- a/frontend/src/pages/feature-ai/ui/AiFeaturePage.tsx
+++ b/frontend/src/pages/feature-ai/ui/AiFeaturePage.tsx
@@ -45,7 +45,6 @@ const FEATURES: FeatureItem[] = [
   },
 ]
 
-const ACCENT = '#FFD84D'
 const DARK = '#17150F'
 const BORDER = 'rgba(23,21,15,.1)'
 
@@ -77,7 +76,7 @@ export function AiFeaturePage() {
               style={{
                 alignSelf: 'flex-start',
                 background: 'rgba(43,80,236,.08)',
-                borderRadius: 999,
+                borderRadius: 'var(--mantine-radius-pill)',
                 padding: '6px 12px',
               }}
             >
@@ -95,7 +94,7 @@ export function AiFeaturePage() {
               style={{ letterSpacing: '-0.5px', textWrap: 'balance' }}
             >
               ИИ{' '}
-              <Box component="span" px={8} style={{ background: ACCENT, borderRadius: 8 }}>
+              <Box component="span" px={8} style={{ background: 'var(--mantine-color-accent-5)', borderRadius: 8 }}>
                 пишет
               </Box>{' '}
               — вы публикуете
@@ -187,7 +186,7 @@ export function AiFeaturePage() {
                 onClick={() => open('register')}
                 styles={{
                   root: {
-                    background: ACCENT,
+                    background: 'var(--mantine-color-accent-5)',
                     color: DARK,
                     fontWeight: 700,
                   },

--- a/frontend/src/pages/feature-autoposting/ui/AutopostingPage.tsx
+++ b/frontend/src/pages/feature-autoposting/ui/AutopostingPage.tsx
@@ -153,7 +153,7 @@ export function AutopostingPage() {
                 style={{ letterSpacing: '-.7px', textWrap: 'balance' }}
               >
                 Посты выходят по расписанию —{' '}
-                <Box component="span" px={8} style={{ background: '#FFD84D', borderRadius: 8 }}>
+                <Box component="span" px={8} style={{ background: 'var(--mantine-color-accent-5)', borderRadius: 8 }}>
                   без вас
                 </Box>
               </Title>
@@ -258,7 +258,7 @@ export function AutopostingPage() {
                       style={{
                         color: item.statusColor,
                         background: item.statusBg,
-                        borderRadius: 999,
+                        borderRadius: 'var(--mantine-radius-pill)',
                         padding: '4px 10px',
                         flex: 'none',
                         whiteSpace: 'nowrap',
@@ -356,7 +356,7 @@ export function AutopostingPage() {
                 onClick={() => open('register')}
                 styles={{
                   root: {
-                    background: '#FFD84D',
+                    background: 'var(--mantine-color-accent-5)',
                     color: '#17150F',
                     fontWeight: 700,
                   },

--- a/frontend/src/pages/feature-crossposting/ui/CrosspostingPage.tsx
+++ b/frontend/src/pages/feature-crossposting/ui/CrosspostingPage.tsx
@@ -76,7 +76,7 @@ export function CrosspostingPage() {
                   alignSelf: 'flex-start',
                   background: 'rgba(43,80,236,.08)',
                   color: '#2B50EC',
-                  borderRadius: 999,
+                  borderRadius: 'var(--mantine-radius-pill)',
                   padding: '6px 12px',
                   fontSize: 12,
                   fontWeight: 700,
@@ -98,7 +98,7 @@ export function CrosspostingPage() {
                   component="span"
                   inherit
                   style={{
-                    background: '#FFD84D',
+                    background: 'var(--mantine-color-accent-5)',
                     padding: '0 8px',
                     borderRadius: 8,
                   }}
@@ -193,7 +193,7 @@ export function CrosspostingPage() {
                   onClick={() => open('register')}
                   styles={{
                     root: {
-                      background: '#FFD84D',
+                      background: 'var(--mantine-color-accent-5)',
                       color: '#17150F',
                       fontWeight: 700,
                     },

--- a/frontend/src/pages/landing/ui/sections/AiAssistantSection.tsx
+++ b/frontend/src/pages/landing/ui/sections/AiAssistantSection.tsx
@@ -59,8 +59,8 @@ export function AiAssistantSection() {
                   style={{
                     width: 32,
                     height: 32,
-                    borderRadius: 999,
-                    background: '#FFD84D',
+                    borderRadius: 'var(--mantine-radius-pill)',
+                    background: 'var(--mantine-color-accent-5)',
                     display: 'flex',
                     alignItems: 'center',
                     justifyContent: 'center',

--- a/frontend/src/pages/landing/ui/sections/ComparisonSection.tsx
+++ b/frontend/src/pages/landing/ui/sections/ComparisonSection.tsx
@@ -3,13 +3,12 @@ import type { ReactNode } from 'react'
 import { IconCheck } from '@tabler/icons-react'
 import { Section } from '../Section'
 
-const GREEN = '#22A06B'
 const HIGHLIGHT_BG = 'rgba(43, 80, 236, 0.05)'
 
 /** Зелёная галочка для колонки «Отложка». */
 function UsCheck({ label }: { label?: string }) {
   return (
-    <Text component="span" c={GREEN} fw={700} fz="sm" style={{ whiteSpace: 'nowrap' }}>
+    <Text component="span" c="success.6" fw={700} fz="sm" style={{ whiteSpace: 'nowrap' }}>
       <IconCheck size={16} stroke={2.4} style={{ verticalAlign: '-3px' }} />
       {label ? ` ${label}` : ''}
     </Text>

--- a/frontend/src/pages/landing/ui/sections/CrosspostingSection.tsx
+++ b/frontend/src/pages/landing/ui/sections/CrosspostingSection.tsx
@@ -24,7 +24,7 @@ export function CrosspostingSection() {
             <Center
               w={36}
               h={36}
-              style={{ borderRadius: 999, background: '#FFD84D', fontWeight: 800, fontSize: 15 }}
+              style={{ borderRadius: 'var(--mantine-radius-pill)', background: 'var(--mantine-color-accent-5)', fontWeight: 800, fontSize: 15 }}
             >
               М
             </Center>
@@ -80,7 +80,7 @@ export function CrosspostingSection() {
               <Text ml="auto" fz={12} c="dimmed" style={{ whiteSpace: 'nowrap' }}>
                 Опубликовано · {PUBLISHED_TIMES[index]}
               </Text>
-              <ThemeIcon color="teal" radius={999} size={18} variant="filled">
+              <ThemeIcon color="teal" radius="pill" size={18} variant="filled">
                 <IconCheck size={11} stroke={3} />
               </ThemeIcon>
             </Group>

--- a/frontend/src/pages/landing/ui/sections/CtaSection.tsx
+++ b/frontend/src/pages/landing/ui/sections/CtaSection.tsx
@@ -33,7 +33,7 @@ export function CtaSection() {
               radius="md"
               styles={{
                 root: {
-                  background: '#FFD84D',
+                  background: 'var(--mantine-color-accent-5)',
                   color: '#17150F',
                   fontWeight: 700,
                 },

--- a/frontend/src/pages/landing/ui/sections/HeroSection.tsx
+++ b/frontend/src/pages/landing/ui/sections/HeroSection.tsx
@@ -115,7 +115,7 @@ export function HeroSection() {
               style={{ letterSpacing: '-.8px', textWrap: 'balance' }}
             >
               Посты выходят{' '}
-              <Box component="span" px={8} style={{ background: '#FFD84D', borderRadius: 8 }}>
+              <Box component="span" px={8} style={{ background: 'var(--mantine-color-accent-5)', borderRadius: 8 }}>
                 сами
               </Box>{' '}
               — даже когда вы спите

--- a/frontend/src/pages/pricing/ui/PricingPage.tsx
+++ b/frontend/src/pages/pricing/ui/PricingPage.tsx
@@ -20,7 +20,6 @@ import { MarketingFooter } from '@/widgets/marketing-footer'
 import { useAuthModal } from '@/features/auth'
 
 const BRAND = '#2B50EC'
-const ACCENT = '#FFD84D'
 const INK = '#17150F'
 const BORDER = 'rgba(23,21,15,.12)'
 
@@ -416,7 +415,7 @@ export function PricingPage() {
                 size="md"
                 radius="md"
                 onClick={() => open('register')}
-                styles={{ root: { background: ACCENT, color: INK, fontWeight: 700 } }}
+                styles={{ root: { background: 'var(--mantine-color-accent-5)', color: INK, fontWeight: 700 } }}
               >
                 Создать аккаунт
               </Button>

--- a/frontend/src/shared/ui/NetworkPill.tsx
+++ b/frontend/src/shared/ui/NetworkPill.tsx
@@ -36,7 +36,7 @@ export function NetworkPill({ network, variant = 'pill' }: NetworkPillProps) {
       wrap="nowrap"
       style={{
         padding: '6px 12px 6px 6px',
-        borderRadius: 999,
+        borderRadius: 'var(--mantine-radius-pill)',
         border: `1px solid ${network.color}59`,
         background: `${network.color}14`,
       }}

--- a/frontend/src/widgets/app-shell/ui/AppLayout.tsx
+++ b/frontend/src/widgets/app-shell/ui/AppLayout.tsx
@@ -29,6 +29,7 @@ import {
 import { Link, Outlet, useLocation, useNavigate } from 'react-router-dom'
 import { Logo } from '@/shared/ui'
 import { useCurrentProject, useProjects, setCurrentProject } from '@/entities/project'
+import { logout } from '@/entities/session'
 import { useDispatch } from 'react-redux'
 import { CreateProjectModal } from '@/features/create-project'
 import { useAppModals } from '@/features/app-modals'
@@ -154,7 +155,14 @@ function PlanWidget() {
 export function AppLayout() {
   const { pathname } = useLocation()
   const navigate = useNavigate()
+  const dispatch = useDispatch()
   const [newProjectOpened, newProject] = useDisclosure(false)
+
+  const handleLogout = () => {
+    // Мок-сессия: сбрасываем признак входа, чтобы /app/* снова требовал входа.
+    dispatch(logout())
+    navigate('/')
+  }
 
   return (
     <AppShell navbar={{ width: 264, breakpoint: 'sm' }} padding="md">
@@ -200,12 +208,7 @@ export function AppLayout() {
                 </Text>
               </Group>
               <Tooltip label="Выйти">
-                <ActionIcon
-                  variant="subtle"
-                  color="gray"
-                  onClick={() => navigate('/')}
-                  aria-label="Выйти"
-                >
+                <ActionIcon variant="subtle" color="gray" onClick={handleLogout} aria-label="Выйти">
                   <IconLogout size={18} />
                 </ActionIcon>
               </Tooltip>

--- a/frontend/src/widgets/app-shell/ui/AppLayout.tsx
+++ b/frontend/src/widgets/app-shell/ui/AppLayout.tsx
@@ -1,5 +1,5 @@
 import {
-  ActionIcon,
+  Anchor,
   AppShell,
   Avatar,
   Box,
@@ -11,7 +11,6 @@ import {
   ScrollArea,
   Stack,
   Text,
-  Tooltip,
   UnstyledButton,
 } from '@mantine/core'
 import { useDisclosure } from '@mantine/hooks'
@@ -20,7 +19,6 @@ import {
   IconChartBar,
   IconChevronDown,
   IconClockHour4,
-  IconLogout,
   IconPhoto,
   IconPlus,
   IconSettings,
@@ -50,6 +48,8 @@ function ProjectSwitcher({ onNewProject }: { onNewProject: () => void }) {
   const current = useCurrentProject()
   const active = projects.filter((p) => !p.archived)
   const archived = projects.filter((p) => p.archived)
+  // Порядковый номер текущего проекта среди активных — для подписи «проект N из M»
+  const activeIndex = current ? active.findIndex((p) => p.id === current.id) : -1
 
   const dot = (color: string, letter: string) => (
     <Box
@@ -72,7 +72,7 @@ function ProjectSwitcher({ onNewProject }: { onNewProject: () => void }) {
   )
 
   return (
-    <Menu width={232} position="bottom-start" shadow="md">
+    <Menu width="target" position="bottom-start" shadow="md">
       <Menu.Target>
         <UnstyledButton
           style={{
@@ -84,9 +84,16 @@ function ProjectSwitcher({ onNewProject }: { onNewProject: () => void }) {
         >
           <Group gap={8} wrap="nowrap">
             {current ? dot(current.color, current.letter) : null}
-            <Text fw={600} fz={14} lineClamp={1} style={{ flex: 1 }}>
-              {current?.name ?? 'Проект'}
-            </Text>
+            <Box style={{ flex: 1, minWidth: 0 }}>
+              <Text fw={600} fz={14} lineClamp={1}>
+                {current?.name ?? 'Проект'}
+              </Text>
+              {activeIndex >= 0 && (
+                <Text fz={11} c="dimmed">
+                  проект {activeIndex + 1} из {active.length}
+                </Text>
+              )}
+            </Box>
             <IconChevronDown size={16} />
           </Group>
         </UnstyledButton>
@@ -123,6 +130,9 @@ function ProjectSwitcher({ onNewProject }: { onNewProject: () => void }) {
 
 function PlanWidget() {
   const { openUpgrade } = useAppModals()
+  // Тариф пока из заглушки; на «Старте» предлагаем улучшение, на остальных — смену
+  const plan: string = 'Бесплатный'
+  const upgradeLabel = plan === 'Старт' ? 'Улучшить тариф' : 'Сменить тариф'
   return (
     <Box
       p="sm"
@@ -134,7 +144,7 @@ function PlanWidget() {
     >
       <Group justify="space-between" mb={4}>
         <Text fw={700} fz={13}>
-          Бесплатный
+          {plan}
         </Text>
         <Text fz={11} c="dimmed">
           до 12 дек
@@ -145,7 +155,7 @@ function PlanWidget() {
       </Text>
       <Progress value={10} size="sm" color="brand" mb="sm" />
       <Button size="xs" variant="light" fullWidth onClick={openUpgrade}>
-        Улучшить тариф
+        {upgradeLabel} →
       </Button>
     </Box>
   )
@@ -165,7 +175,7 @@ export function AppLayout() {
   }
 
   return (
-    <AppShell navbar={{ width: 264, breakpoint: 'sm' }} padding="md">
+    <AppShell navbar={{ width: 236, breakpoint: 'sm' }} padding="md">
       <AppShell.Navbar p="sm" bg="white">
         <AppShell.Section>
           <Box px={6} py={4}>
@@ -198,20 +208,24 @@ export function AppLayout() {
         <AppShell.Section mt="md">
           <Stack gap="sm">
             <PlanWidget />
-            <Group justify="space-between" wrap="nowrap" px={4}>
-              <Group gap={8} wrap="nowrap">
-                <Avatar color="brand" radius="xl" size={30}>
-                  М
-                </Avatar>
+            <Group gap={8} wrap="nowrap" px={4}>
+              <Avatar color="brand" radius="xl" size={30}>
+                М
+              </Avatar>
+              <Box>
                 <Text fw={600} fz={13} lineClamp={1}>
                   Мария
                 </Text>
-              </Group>
-              <Tooltip label="Выйти">
-                <ActionIcon variant="subtle" color="gray" onClick={handleLogout} aria-label="Выйти">
-                  <IconLogout size={18} />
-                </ActionIcon>
-              </Tooltip>
+                <Anchor
+                  component="button"
+                  type="button"
+                  fz={11.5}
+                  c="dimmed"
+                  onClick={handleLogout}
+                >
+                  Выйти
+                </Anchor>
+              </Box>
             </Group>
           </Stack>
         </AppShell.Section>


### PR DESCRIPTION
Closes #203

Стек: базируется на #247 (#202, линт) — мержить после него; GitHub перетаргетит на main автоматически.

## Что сделано
- **Палитра `success`** (10 оттенков, #22A06B на index 6) в `theme.ts`; зелёная галочка таблицы сравнения — `c="success.6"` вместо хардкода. Аватарные цвета (проекты, авторы отзывов) осознанно не тронуты — это не семантический токен.
- **Шкала `spacing`**: xs/sm/md/lg/xl = 8/12/16/20/32px (ритм 8px из макета; от дефолта Mantine отличается только xs: 10→8px).
- **`radius.pill` = 999px**: все инлайновые `borderRadius: 999` заменены на `var(--mantine-radius-pill)` / `radius="pill"` (NetworkPill, демо-секции лендинга, страницы фич).
- **Жёлтый акцент**: хардкоды `#FFD84D` и локальные константы `ACCENT` → `var(--mantine-color-accent-5)` (это ровно #FFD84D из палитры).

## Проверено
- `npm run lint`, `typecheck` — чисто
- Runtime (headless Chrome): `--mantine-radius-pill: 999px`, `--mantine-color-success-6: #22a06b`, дефолтные радиусы не затёрты (md = 0.5rem), spacing-xs = 8px; скриншот лендинга — визуально без изменений