### PR TITLE
feat(frontend): entities/subscription — мок-квоты, живой индикатор ИИ в сайдбаре

### DIFF
--- a/frontend/src/entities/subscription/api/subscriptionApi.ts
+++ b/frontend/src/entities/subscription/api/subscriptionApi.ts
@@ -1,0 +1,45 @@
+import { useQuery } from '@tanstack/react-query'
+import type { QueryClient } from '@tanstack/react-query'
+import type { Subscription } from '../model/types'
+
+export const subscriptionKeys = {
+  all: ['subscription'] as const,
+}
+
+// TODO (Design First): заменить мок на GET /billing/subscription (oapi-codegen хук).
+// usage.scheduledPosts согласован с моками entities/scheduled-post (7 постов со статусом scheduled).
+const SEED: Subscription = {
+  plan: 'Бесплатный',
+  renewsAt: '2026-12-12',
+  limits: { aiRequests: 50, scheduledPosts: 10 },
+  usage: { aiRequests: 5, scheduledPosts: 7 },
+}
+
+export function useSubscription() {
+  return useQuery({
+    queryKey: subscriptionKeys.all,
+    queryFn: async (): Promise<Subscription> => SEED,
+    // Отдаём синхронно, чтобы квоты были доступны на первом рендере (сайдбар, композер).
+    initialData: SEED,
+    staleTime: Infinity,
+  })
+}
+
+/**
+ * Демо-мутатор: +1 использованная ИИ-генерация.
+ * Вызывать из обработчиков генерации (композер, панель ИИ) с queryClient из useQueryClient().
+ */
+export function incrementAiUsage(queryClient: QueryClient) {
+  queryClient.setQueryData<Subscription>(subscriptionKeys.all, (old = SEED) => ({
+    ...old,
+    usage: { ...old.usage, aiRequests: old.usage.aiRequests + 1 },
+  }))
+}
+
+/** Демо-мутатор: частично переписать usage (например, счётчик запланированных постов). */
+export function setUsage(queryClient: QueryClient, patch: Partial<Subscription['usage']>) {
+  queryClient.setQueryData<Subscription>(subscriptionKeys.all, (old = SEED) => ({
+    ...old,
+    usage: { ...old.usage, ...patch },
+  }))
+}

--- a/frontend/src/entities/subscription/index.ts
+++ b/frontend/src/entities/subscription/index.ts
@@ -1,0 +1,9 @@
+export {
+  useSubscription,
+  subscriptionKeys,
+  incrementAiUsage,
+  setUsage,
+} from './api/subscriptionApi'
+export { useQuota } from './model/useQuota'
+export type { QuotaState } from './model/useQuota'
+export type { Subscription } from './model/types'

--- a/frontend/src/entities/subscription/model/types.ts
+++ b/frontend/src/entities/subscription/model/types.ts
@@ -1,0 +1,20 @@
+/**
+ * Подписка воркспейса: тариф и квоты периода.
+ * Единый источник для сайдбара (PlanWidget), композера, панели ИИ и биллинга.
+ */
+export interface Subscription {
+  /** Название тарифа («Бесплатный», «Старт», «Про», «Агентство»). */
+  plan: string
+  /** Дата окончания оплаченного периода (ISO-строка). */
+  renewsAt: string
+  /** Лимиты за период; Infinity = безлимит. */
+  limits: {
+    aiRequests: number
+    scheduledPosts: number
+  }
+  /** Сколько уже использовано за период. */
+  usage: {
+    aiRequests: number
+    scheduledPosts: number
+  }
+}

--- a/frontend/src/entities/subscription/model/useQuota.ts
+++ b/frontend/src/entities/subscription/model/useQuota.ts
@@ -1,0 +1,17 @@
+import { useSubscription } from '../api/subscriptionApi'
+
+/** Состояние квоты одного вида ресурса. Limit = Infinity означает безлимит. */
+export interface QuotaState {
+  used: number
+  limit: number
+  exhausted: boolean
+}
+
+/** Квота по виду ресурса: ИИ-генерации ('ai') или запланированные посты ('posts'). */
+export function useQuota(kind: 'ai' | 'posts'): QuotaState {
+  const { data } = useSubscription()
+  const used = kind === 'ai' ? data.usage.aiRequests : data.usage.scheduledPosts
+  const limit = kind === 'ai' ? data.limits.aiRequests : data.limits.scheduledPosts
+  // Безлимит (Infinity) исчерпать нельзя
+  return { used, limit, exhausted: Number.isFinite(limit) && used >= limit }
+}

--- a/frontend/src/features/create-project/api/useRestoreProject.ts
+++ b/frontend/src/features/create-project/api/useRestoreProject.ts
@@ -1,0 +1,19 @@
+import { useQueryClient } from '@tanstack/react-query'
+import { notifications } from '@mantine/notifications'
+import { projectKeys } from '@/entities/project'
+import type { Project } from '@/entities/project'
+
+/**
+ * Клиентское восстановление проекта из архива (заглушка): снимаем флаг archived в кэше TanStack Query.
+ * TODO (Design First, backlog #117): POST /projects/{id}/restore.
+ */
+export function useRestoreProject() {
+  const queryClient = useQueryClient()
+
+  return (id: string) => {
+    queryClient.setQueryData<Project[]>(projectKeys.all, (old = []) =>
+      old.map((p) => (p.id === id ? { ...p, archived: false } : p)),
+    )
+    notifications.show({ color: 'green', message: 'Проект восстановлен из архива (демо)' })
+  }
+}

--- a/frontend/src/features/create-project/index.ts
+++ b/frontend/src/features/create-project/index.ts
@@ -1,2 +1,3 @@
 export { CreateProjectModal } from './ui/CreateProjectModal'
 export { useCreateProject } from './api/useCreateProject'
+export { useRestoreProject } from './api/useRestoreProject'

--- a/frontend/src/features/create-project/ui/CreateProjectModal.tsx
+++ b/frontend/src/features/create-project/ui/CreateProjectModal.tsx
@@ -32,7 +32,7 @@ export function CreateProjectModal({ opened, onClose }: CreateProjectModalProps)
         <Stack gap="md">
           <TextInput
             label="Название проекта"
-            placeholder="Мой бренд"
+            placeholder="Цветочная «Пион»"
             withAsterisk
             data-autofocus
             {...form.getInputProps('name')}
@@ -43,9 +43,12 @@ export function CreateProjectModal({ opened, onClose }: CreateProjectModalProps)
             </Text>
             <ColorSwatchPicker value={color} onChange={setColor} />
           </div>
-          <Button type="submit" fullWidth mt={4}>
+          <Button type="submit" fullWidth mt={4} disabled={form.values.name.trim().length === 0}>
             Создать проект
           </Button>
+          <Text c="dimmed" fz="xs">
+            Площадки подключите после создания — на вкладке «Календарь».
+          </Text>
         </Stack>
       </form>
     </Modal>

--- a/frontend/src/widgets/app-shell/ui/AppLayout.tsx
+++ b/frontend/src/widgets/app-shell/ui/AppLayout.tsx
@@ -17,6 +17,7 @@ import { useDisclosure } from '@mantine/hooks'
 import {
   IconCalendar,
   IconChartBar,
+  IconCheck,
   IconChevronDown,
   IconClockHour4,
   IconPhoto,
@@ -25,14 +26,17 @@ import {
   IconUsers,
 } from '@tabler/icons-react'
 import { Link, Outlet, useLocation, useNavigate } from 'react-router-dom'
+import { useQueryClient } from '@tanstack/react-query'
 import dayjs from 'dayjs'
 import 'dayjs/locale/ru'
 import { Logo } from '@/shared/ui'
 import { useCurrentProject, useProjects, setCurrentProject } from '@/entities/project'
 import { useSubscription, useQuota } from '@/entities/subscription'
+import { mediaKeys } from '@/entities/media'
+import { scheduledPostKeys } from '@/entities/scheduled-post'
 import { logout } from '@/entities/session'
 import { useDispatch } from 'react-redux'
-import { CreateProjectModal } from '@/features/create-project'
+import { CreateProjectModal, useRestoreProject } from '@/features/create-project'
 import { useAppModals } from '@/features/app-modals'
 import { AppModals } from './AppModals'
 
@@ -47,6 +51,8 @@ const NAV = [
 
 function ProjectSwitcher({ onNewProject }: { onNewProject: () => void }) {
   const dispatch = useDispatch()
+  const queryClient = useQueryClient()
+  const restoreProject = useRestoreProject()
   const { data: projects = [] } = useProjects()
   const current = useCurrentProject()
   const active = projects.filter((p) => !p.archived)
@@ -54,14 +60,22 @@ function ProjectSwitcher({ onNewProject }: { onNewProject: () => void }) {
   // Порядковый номер текущего проекта среди активных — для подписи «проект N из M»
   const activeIndex = current ? active.findIndex((p) => p.id === current.id) : -1
 
-  const dot = (color: string, letter: string) => (
+  const selectProject = (id: string) => {
+    dispatch(setCurrentProject(id))
+    // Разделы перечитывают мок-данные под новый проект
+    // (ключи с projectId появятся вместе с реальным API — см. #147)
+    queryClient.invalidateQueries({ queryKey: scheduledPostKeys.all })
+    queryClient.invalidateQueries({ queryKey: mediaKeys.all })
+  }
+
+  const dot = (color: string, letter: string, muted = false) => (
     <Box
       style={{
         width: 26,
         height: 26,
         borderRadius: 8,
-        background: color,
-        color: '#fff',
+        background: muted ? 'rgba(23,21,15,0.12)' : color,
+        color: muted ? 'rgba(23,21,15,0.5)' : '#fff',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
@@ -107,7 +121,12 @@ function ProjectSwitcher({ onNewProject }: { onNewProject: () => void }) {
           <Menu.Item
             key={p.id}
             leftSection={dot(p.color, p.letter)}
-            onClick={() => dispatch(setCurrentProject(p.id))}
+            rightSection={
+              p.id === current?.id ? (
+                <IconCheck size={16} color="var(--mantine-color-brand-6)" stroke={2.5} />
+              ) : undefined
+            }
+            onClick={() => selectProject(p.id)}
           >
             {p.name}
           </Menu.Item>
@@ -120,9 +139,21 @@ function ProjectSwitcher({ onNewProject }: { onNewProject: () => void }) {
             <Menu.Divider />
             <Menu.Label>Архив</Menu.Label>
             {archived.map((p) => (
-              <Menu.Item key={p.id} leftSection={dot(p.color, p.letter)} disabled>
-                {p.name}
-              </Menu.Item>
+              <Group key={p.id} gap={8} wrap="nowrap" px={10} py={6}>
+                {dot(p.color, p.letter, true)}
+                <Text fz={13} fw={600} c="dimmed" lineClamp={1} style={{ flex: 1 }}>
+                  {p.name}
+                </Text>
+                <Anchor
+                  component="button"
+                  type="button"
+                  fz={11.5}
+                  fw={700}
+                  onClick={() => restoreProject(p.id)}
+                >
+                  Вернуть
+                </Anchor>
+              </Group>
             ))}
           </>
         )}

--- a/frontend/src/widgets/app-shell/ui/AppLayout.tsx
+++ b/frontend/src/widgets/app-shell/ui/AppLayout.tsx
@@ -25,8 +25,11 @@ import {
   IconUsers,
 } from '@tabler/icons-react'
 import { Link, Outlet, useLocation, useNavigate } from 'react-router-dom'
+import dayjs from 'dayjs'
+import 'dayjs/locale/ru'
 import { Logo } from '@/shared/ui'
 import { useCurrentProject, useProjects, setCurrentProject } from '@/entities/project'
+import { useSubscription, useQuota } from '@/entities/subscription'
 import { logout } from '@/entities/session'
 import { useDispatch } from 'react-redux'
 import { CreateProjectModal } from '@/features/create-project'
@@ -130,9 +133,19 @@ function ProjectSwitcher({ onNewProject }: { onNewProject: () => void }) {
 
 function PlanWidget() {
   const { openUpgrade } = useAppModals()
-  // Тариф пока из заглушки; на «Старте» предлагаем улучшение, на остальных — смену
-  const plan: string = 'Бесплатный'
-  const upgradeLabel = plan === 'Старт' ? 'Улучшить тариф' : 'Сменить тариф'
+  const { data: subscription } = useSubscription()
+  const { used, limit, exhausted } = useQuota('ai')
+
+  // Безлимитный тариф: показываем «безлимит» без счётчика и прогресс-бара
+  const unlimited = !Number.isFinite(limit)
+  const percent = unlimited ? 0 : Math.min(100, Math.round((used / limit) * 100))
+  // Подсветка: с ~80% — предупреждение, при исчерпании — цвет ошибки
+  const nearLimit = !unlimited && !exhausted && percent >= 80
+  const quotaColor = exhausted ? 'red' : nearLimit ? 'orange' : 'brand'
+  // На «Старте» предлагаем улучшение, на остальных тарифах — смену
+  const upgradeLabel = subscription.plan === 'Старт' ? 'Улучшить тариф' : 'Сменить тариф'
+  const renewsLabel = `до ${dayjs(subscription.renewsAt).locale('ru').format('D MMM').replace('.', '')}`
+
   return (
     <Box
       p="sm"
@@ -144,17 +157,35 @@ function PlanWidget() {
     >
       <Group justify="space-between" mb={4}>
         <Text fw={700} fz={13}>
-          {plan}
+          {subscription.plan}
         </Text>
         <Text fz={11} c="dimmed">
-          до 12 дек
+          {renewsLabel}
         </Text>
       </Group>
-      <Text fz={11} c="dimmed" mb={4}>
-        ИИ-тексты: 5 / 50
-      </Text>
-      <Progress value={10} size="sm" color="brand" mb="sm" />
-      <Button size="xs" variant="light" fullWidth onClick={openUpgrade}>
+      {unlimited ? (
+        <Text fz={11} c="dimmed" mb="xs">
+          ИИ-тексты: безлимит
+        </Text>
+      ) : (
+        <>
+          <Text fz={11} c={exhausted ? 'red.7' : nearLimit ? 'orange.8' : 'dimmed'} mb={4}>
+            ИИ-тексты: {used} / {limit}
+          </Text>
+          <Progress value={percent} size="sm" color={quotaColor} mb="sm" />
+          {exhausted && (
+            <Text fz={11} c="red.7" mb="xs">
+              Лимит на период исчерпан — поднимите его апгрейдом тарифа
+            </Text>
+          )}
+        </>
+      )}
+      <Button
+        size="xs"
+        variant={exhausted || nearLimit ? 'filled' : 'light'}
+        fullWidth
+        onClick={openUpgrade}
+      >
         {upgradeLabel} →
       </Button>
     </Box>


### PR DESCRIPTION
Closes #207

Стек: после PR #189-sidebar.

- **entities/subscription — единая сущность под всех потребителей** (#206 панель ИИ, #195 счётчик композера, #211 квота постов, #210 модалка апгрейда): `Subscription = { plan, renewsAt, limits{aiRequests, scheduledPosts}, usage{...} }`, useSubscription по эталону projectApi (SEED/initialData/staleTime Infinity), мутаторы `incrementAiUsage(queryClient)` / `setUsage(...)`, хук `useQuota('ai'|'posts')` → { used, limit, exhausted } (Infinity = безлимит)
- PlanWidget подключён: тариф/«до 12 дек»/«ИИ-тексты: 5 / 50» из данных; ≥80% — orange, исчерпано — red + подпись «Лимит на период исчерпан…», кнопка становится filled; безлимит — без прогресс-бара
- SEED: «Бесплатный», aiRequests 5/50, scheduledPosts 7/10 (7 согласовано с мок-постами)

Инкремент из композера и disabled «Сгенерировать» — в #195/#206 (хелперы уже готовы).

Проверено: lint/tsc/build чисто; в живом кабинете «ИИ-тексты: 5 / 50» и «до 12 дек» рендерятся из сущности.