### PR TITLE
feat(frontend): свитчер проектов — галочка, восстановление из архива, реакция разделов

### DIFF
--- a/frontend/src/features/create-project/api/useRestoreProject.ts
+++ b/frontend/src/features/create-project/api/useRestoreProject.ts
@@ -1,0 +1,19 @@
+import { useQueryClient } from '@tanstack/react-query'
+import { notifications } from '@mantine/notifications'
+import { projectKeys } from '@/entities/project'
+import type { Project } from '@/entities/project'
+
+/**
+ * Клиентское восстановление проекта из архива (заглушка): снимаем флаг archived в кэше TanStack Query.
+ * TODO (Design First, backlog #117): POST /projects/{id}/restore.
+ */
+export function useRestoreProject() {
+  const queryClient = useQueryClient()
+
+  return (id: string) => {
+    queryClient.setQueryData<Project[]>(projectKeys.all, (old = []) =>
+      old.map((p) => (p.id === id ? { ...p, archived: false } : p)),
+    )
+    notifications.show({ color: 'green', message: 'Проект восстановлен из архива (демо)' })
+  }
+}

--- a/frontend/src/features/create-project/index.ts
+++ b/frontend/src/features/create-project/index.ts
@@ -1,2 +1,3 @@
 export { CreateProjectModal } from './ui/CreateProjectModal'
 export { useCreateProject } from './api/useCreateProject'
+export { useRestoreProject } from './api/useRestoreProject'

--- a/frontend/src/features/create-project/ui/CreateProjectModal.tsx
+++ b/frontend/src/features/create-project/ui/CreateProjectModal.tsx
@@ -32,7 +32,7 @@ export function CreateProjectModal({ opened, onClose }: CreateProjectModalProps)
         <Stack gap="md">
           <TextInput
             label="Название проекта"
-            placeholder="Мой бренд"
+            placeholder="Цветочная «Пион»"
             withAsterisk
             data-autofocus
             {...form.getInputProps('name')}
@@ -43,9 +43,12 @@ export function CreateProjectModal({ opened, onClose }: CreateProjectModalProps)
             </Text>
             <ColorSwatchPicker value={color} onChange={setColor} />
           </div>
-          <Button type="submit" fullWidth mt={4}>
+          <Button type="submit" fullWidth mt={4} disabled={form.values.name.trim().length === 0}>
             Создать проект
           </Button>
+          <Text c="dimmed" fz="xs">
+            Площадки подключите после создания — на вкладке «Календарь».
+          </Text>
         </Stack>
       </form>
     </Modal>

--- a/frontend/src/widgets/app-shell/ui/AppLayout.tsx
+++ b/frontend/src/widgets/app-shell/ui/AppLayout.tsx
@@ -17,6 +17,7 @@ import { useDisclosure } from '@mantine/hooks'
 import {
   IconCalendar,
   IconChartBar,
+  IconCheck,
   IconChevronDown,
   IconClockHour4,
   IconPhoto,
@@ -25,14 +26,17 @@ import {
   IconUsers,
 } from '@tabler/icons-react'
 import { Link, Outlet, useLocation, useNavigate } from 'react-router-dom'
+import { useQueryClient } from '@tanstack/react-query'
 import dayjs from 'dayjs'
 import 'dayjs/locale/ru'
 import { Logo } from '@/shared/ui'
 import { useCurrentProject, useProjects, setCurrentProject } from '@/entities/project'
 import { useSubscription, useQuota } from '@/entities/subscription'
+import { mediaKeys } from '@/entities/media'
+import { scheduledPostKeys } from '@/entities/scheduled-post'
 import { logout } from '@/entities/session'
 import { useDispatch } from 'react-redux'
-import { CreateProjectModal } from '@/features/create-project'
+import { CreateProjectModal, useRestoreProject } from '@/features/create-project'
 import { useAppModals } from '@/features/app-modals'
 import { AppModals } from './AppModals'
 
@@ -47,6 +51,8 @@ const NAV = [
 
 function ProjectSwitcher({ onNewProject }: { onNewProject: () => void }) {
   const dispatch = useDispatch()
+  const queryClient = useQueryClient()
+  const restoreProject = useRestoreProject()
   const { data: projects = [] } = useProjects()
   const current = useCurrentProject()
   const active = projects.filter((p) => !p.archived)
@@ -54,14 +60,22 @@ function ProjectSwitcher({ onNewProject }: { onNewProject: () => void }) {
   // Порядковый номер текущего проекта среди активных — для подписи «проект N из M»
   const activeIndex = current ? active.findIndex((p) => p.id === current.id) : -1
 
-  const dot = (color: string, letter: string) => (
+  const selectProject = (id: string) => {
+    dispatch(setCurrentProject(id))
+    // Разделы перечитывают мок-данные под новый проект
+    // (ключи с projectId появятся вместе с реальным API — см. #147)
+    queryClient.invalidateQueries({ queryKey: scheduledPostKeys.all })
+    queryClient.invalidateQueries({ queryKey: mediaKeys.all })
+  }
+
+  const dot = (color: string, letter: string, muted = false) => (
     <Box
       style={{
         width: 26,
         height: 26,
         borderRadius: 8,
-        background: color,
-        color: '#fff',
+        background: muted ? 'rgba(23,21,15,0.12)' : color,
+        color: muted ? 'rgba(23,21,15,0.5)' : '#fff',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
@@ -107,7 +121,12 @@ function ProjectSwitcher({ onNewProject }: { onNewProject: () => void }) {
           <Menu.Item
             key={p.id}
             leftSection={dot(p.color, p.letter)}
-            onClick={() => dispatch(setCurrentProject(p.id))}
+            rightSection={
+              p.id === current?.id ? (
+                <IconCheck size={16} color="var(--mantine-color-brand-6)" stroke={2.5} />
+              ) : undefined
+            }
+            onClick={() => selectProject(p.id)}
           >
             {p.name}
           </Menu.Item>
@@ -120,9 +139,21 @@ function ProjectSwitcher({ onNewProject }: { onNewProject: () => void }) {
             <Menu.Divider />
             <Menu.Label>Архив</Menu.Label>
             {archived.map((p) => (
-              <Menu.Item key={p.id} leftSection={dot(p.color, p.letter)} disabled>
-                {p.name}
-              </Menu.Item>
+              <Group key={p.id} gap={8} wrap="nowrap" px={10} py={6}>
+                {dot(p.color, p.letter, true)}
+                <Text fz={13} fw={600} c="dimmed" lineClamp={1} style={{ flex: 1 }}>
+                  {p.name}
+                </Text>
+                <Anchor
+                  component="button"
+                  type="button"
+                  fz={11.5}
+                  fw={700}
+                  onClick={() => restoreProject(p.id)}
+                >
+                  Вернуть
+                </Anchor>
+              </Group>
             ))}
           </>
         )}


### PR DESCRIPTION
Closes #190

Стек: после PR #207-subscription.

- Галочка активного проекта (IconCheck, brand-токен) в rightSection пункта меню
- Смена проекта: dispatch(setCurrentProject) + invalidateQueries(scheduledPostKeys.all, mediaKeys.all) — разделы перечитывают моки; ключи с projectId придут с реальным API (#147)
- Архив: вместо disabled-пункта — приглушённый инициал + ссылка «Вернуть» (новый мок-хук useRestoreProject по образцу useCreateProject, снимает archived через setQueryData + уведомление)
- Полировка «Нового проекта»: placeholder «Цветочная «Пион»», disabled до ввода названия, подсказка про подключение площадок

Проверено: lint/tsc/build чисто; в живом свитчере — галочка у активного, секция «Архив» с «Вернуть».