### PR TITLE
feat(frontend): чипсы-площадки над календарём — статус подключения и фильтр

### DIFF
--- a/frontend/src/app/store/index.ts
+++ b/frontend/src/app/store/index.ts
@@ -3,6 +3,7 @@ import { authModalSlice } from '@/features/auth'
 import { projectSlice } from '@/entities/project'
 import { sessionSlice } from '@/entities/session'
 import { appModalsSlice } from '@/features/app-modals'
+import { calendarFilterSlice } from '@/features/filter-by-platform'
 
 /**
  * Redux Toolkit store — holds ONLY client/UI state (session, filters).
@@ -14,6 +15,7 @@ export const store = configureStore({
     project: projectSlice.reducer,
     session: sessionSlice.reducer,
     appModals: appModalsSlice.reducer,
+    calendarFilter: calendarFilterSlice.reducer,
   },
 })
 

--- a/frontend/src/entities/media/api/mediaApi.ts
+++ b/frontend/src/entities/media/api/mediaApi.ts
@@ -7,15 +7,18 @@ export const mediaKeys = {
 }
 
 /**
- * Медиатека проекта. Пока отдаём мок синхронно через initialData,
- * чтобы сетка была готова на первом рендере.
+ * Медиатека проекта. Мок отдаётся с короткой задержкой, чтобы при переходе
+ * на страницу состояние isLoading было видно скелетонами сетки.
  * TODO (Design First, backlog): заменить queryFn на GET /media (oapi-codegen хук).
  */
 export function useMedia() {
   return useQuery({
     queryKey: mediaKeys.all,
-    queryFn: async (): Promise<Media[]> => MEDIA_MOCK,
-    initialData: MEDIA_MOCK,
+    queryFn: async (): Promise<Media[]> => {
+      // Эмуляция сетевой задержки, пока нет реального API.
+      await new Promise((resolve) => setTimeout(resolve, 400))
+      return MEDIA_MOCK
+    },
     staleTime: Infinity,
   })
 }

--- a/frontend/src/entities/media/index.ts
+++ b/frontend/src/entities/media/index.ts
@@ -1,3 +1,5 @@
 export { useMedia, mediaKeys } from './api/mediaApi'
 export { MEDIA_MOCK } from './model/mock'
+export { MediaTile } from './ui/MediaTile'
+export { MediaThumb } from './ui/MediaThumb'
 export type { Media } from './model/types'

--- a/frontend/src/entities/media/lib/date.ts
+++ b/frontend/src/entities/media/lib/date.ts
@@ -1,0 +1,11 @@
+import dayjs from 'dayjs'
+import 'dayjs/locale/ru'
+
+dayjs.locale('ru')
+
+/** Короткая дата для плитки медиатеки, например «12 ноября». */
+export function formatDateShort(value: string | Date | null | undefined): string {
+  if (!value) return '—'
+  const d = dayjs(value)
+  return d.isValid() ? d.format('D MMMM') : '—'
+}

--- a/frontend/src/entities/media/ui/MediaThumb.tsx
+++ b/frontend/src/entities/media/ui/MediaThumb.tsx
@@ -1,0 +1,13 @@
+import { ThemeIcon } from '@mantine/core'
+import { IconPhoto, IconVideo } from '@tabler/icons-react'
+import type { Media } from '../model/types'
+
+/** Иконка-заглушка миниатюры по типу медиа (пока нет реальных превью с бэкенда). */
+export function MediaThumb({ kind, size = 34 }: { kind: Media['kind']; size?: number }) {
+  const Icon = kind === 'video' ? IconVideo : IconPhoto
+  return (
+    <ThemeIcon variant="light" color="brand" size={size + 22} radius="md">
+      <Icon size={size} stroke={1.6} />
+    </ThemeIcon>
+  )
+}

--- a/frontend/src/entities/media/ui/MediaTile.tsx
+++ b/frontend/src/entities/media/ui/MediaTile.tsx
@@ -1,0 +1,88 @@
+import { Box, Card, Text } from '@mantine/core'
+import type { Media } from '../model/types'
+import { formatDateShort } from '../lib/date'
+import { MediaThumb } from './MediaThumb'
+
+// Фон превью-заглушки — кремовый из макета (docs/design/mockups/app-dashboard.html).
+const PLACEHOLDER_BG = '#F6F4EF'
+
+/** Круглая иконка play поверх превью видео: круг 28px, тёмный фон, белый символ (по макету). */
+function PlayOverlay() {
+  return (
+    <Box
+      style={{
+        position: 'absolute',
+        inset: 0,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <Box
+        component="span"
+        style={{
+          width: 28,
+          height: 28,
+          borderRadius: '50%',
+          background: 'rgba(23,21,15,.72)',
+          color: '#fff',
+          fontSize: 10,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        ▶
+      </Box>
+    </Box>
+  )
+}
+
+interface MediaTileProps {
+  media: Media
+  /** Клик по плитке — открыть предпросмотр. */
+  onClick: () => void
+}
+
+/** Плитка медиатеки: превью-заглушка, имя, размер и дата, play-оверлей для видео. */
+export function MediaTile({ media, onClick }: MediaTileProps) {
+  return (
+    <Card
+      withBorder
+      radius="lg"
+      p="sm"
+      role="button"
+      tabIndex={0}
+      onClick={onClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          onClick()
+        }
+      }}
+      style={{ borderColor: 'rgba(23,21,15,.1)', cursor: 'pointer' }}
+    >
+      <Box
+        mb="sm"
+        style={{
+          position: 'relative',
+          aspectRatio: '4 / 3',
+          borderRadius: 12,
+          background: PLACEHOLDER_BG,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        {/* Для видео вместо иконки-миниатюры — play-оверлей по центру, как в макете */}
+        {media.kind === 'video' ? <PlayOverlay /> : <MediaThumb kind={media.kind} />}
+      </Box>
+      <Text fz={13.5} fw={600} lineClamp={1} title={media.name}>
+        {media.name}
+      </Text>
+      <Text fz={12} c="dimmed" mt={4} lineClamp={1}>
+        {media.sizeLabel} · {formatDateShort(media.uploadedAt)}
+      </Text>
+    </Card>
+  )
+}

--- a/frontend/src/entities/platform-account/index.ts
+++ b/frontend/src/entities/platform-account/index.ts
@@ -1,3 +1,3 @@
-export { useConnections } from './model/hooks'
+export { useConnections, connectionKeys } from './model/hooks'
 export { MOCK_CONNECTIONS } from './model/mock'
 export type { Connection } from './model/types'

--- a/frontend/src/entities/platform-account/model/hooks.ts
+++ b/frontend/src/entities/platform-account/model/hooks.ts
@@ -1,11 +1,23 @@
+import { useQuery } from '@tanstack/react-query'
 import type { Connection } from './types'
 import { MOCK_CONNECTIONS } from './mock'
 
+export const connectionKeys = {
+  all: ['connections'] as const,
+}
+
 /**
  * Подключения площадок текущего проекта.
- * Заглушка на локальном моке — форма ответа повторяет будущий API.
- * TODO (Design First, backlog #118): GET /projects/{id}/connections.
+ * Мок через useQuery (эталон — entities/project/api/projectApi.ts): помимо data,
+ * наружу уходят isLoading/isError — экраны показывают скелетоны и ошибку.
+ * TODO (Design First, backlog #118): заменить мок на GET /projects/{id}/connections.
  */
-export function useConnections(): { data: Connection[] } {
-  return { data: MOCK_CONNECTIONS }
+export function useConnections() {
+  return useQuery({
+    queryKey: connectionKeys.all,
+    queryFn: async (): Promise<Connection[]> => MOCK_CONNECTIONS,
+    // Отдаём синхронно, чтобы статусы были доступны на первом рендере (как в entities/project).
+    initialData: MOCK_CONNECTIONS,
+    staleTime: Infinity,
+  })
 }

--- a/frontend/src/features/filter-by-platform/index.ts
+++ b/frontend/src/features/filter-by-platform/index.ts
@@ -1,0 +1,7 @@
+export {
+  calendarFilterSlice,
+  toggleNetwork,
+  selectActiveNetworkIds,
+} from './model/calendarFilterSlice'
+export type { CalendarFilterState } from './model/calendarFilterSlice'
+export { useCalendarFilter } from './model/hooks'

--- a/frontend/src/features/filter-by-platform/model/calendarFilterSlice.ts
+++ b/frontend/src/features/filter-by-platform/model/calendarFilterSlice.ts
@@ -1,0 +1,36 @@
+import { createSlice } from '@reduxjs/toolkit'
+import type { PayloadAction } from '@reduxjs/toolkit'
+import { NETWORKS } from '@/shared/config'
+
+/**
+ * Фильтр календаря по площадкам (чисто UI-состояние, Redux Toolkit).
+ * Храним набор «активных» networkId: пост показывается, если хотя бы одна
+ * из его площадок активна. Изначально активны все 7 площадок.
+ */
+export interface CalendarFilterState {
+  activeNetworkIds: string[]
+}
+
+const initialState: CalendarFilterState = {
+  activeNetworkIds: NETWORKS.map((n) => n.id),
+}
+
+export const calendarFilterSlice = createSlice({
+  name: 'calendarFilter',
+  initialState,
+  reducers: {
+    toggleNetwork(state, action: PayloadAction<string>) {
+      const id = action.payload
+      if (state.activeNetworkIds.includes(id)) {
+        state.activeNetworkIds = state.activeNetworkIds.filter((n) => n !== id)
+      } else {
+        state.activeNetworkIds.push(id)
+      }
+    },
+  },
+})
+
+export const { toggleNetwork } = calendarFilterSlice.actions
+
+export const selectActiveNetworkIds = (state: { calendarFilter: CalendarFilterState }): string[] =>
+  state.calendarFilter.activeNetworkIds

--- a/frontend/src/features/filter-by-platform/model/hooks.ts
+++ b/frontend/src/features/filter-by-platform/model/hooks.ts
@@ -1,0 +1,13 @@
+import { useDispatch, useSelector } from 'react-redux'
+import { selectActiveNetworkIds, toggleNetwork } from './calendarFilterSlice'
+
+/** Доступ к фильтру календаря: активные площадки и переключение (шаблон — features/app-modals). */
+export function useCalendarFilter() {
+  const dispatch = useDispatch()
+  const activeNetworkIds = useSelector(selectActiveNetworkIds)
+  return {
+    activeNetworkIds,
+    isNetworkActive: (networkId: string) => activeNetworkIds.includes(networkId),
+    toggleNetwork: (networkId: string) => dispatch(toggleNetwork(networkId)),
+  }
+}

--- a/frontend/src/pages/content-plan/ui/ContentPlanPage.tsx
+++ b/frontend/src/pages/content-plan/ui/ContentPlanPage.tsx
@@ -17,8 +17,10 @@ import dayjs from 'dayjs'
 import { NETWORKS } from '@/shared/config'
 import { NetworkPill } from '@/shared/ui'
 import { useAppModals } from '@/features/app-modals'
+import { useCalendarFilter } from '@/features/filter-by-platform'
 import { useContentPlan } from '@/entities/scheduled-post'
 import type { Post } from '@/entities/scheduled-post'
+import { PlatformChips } from './PlatformChips'
 
 const NETWORK_BY_ID = new Map(NETWORKS.map((n) => [n.id, n]))
 const WEEKDAYS = ['Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб', 'Вс']
@@ -36,10 +38,13 @@ export function ContentPlanPage() {
   const [scale, setScale] = useState<'week' | 'month'>('week')
   const { openComposer, openConnectPlatform } = useAppModals()
   const { data: posts } = useContentPlan()
+  const { activeNetworkIds } = useCalendarFilter()
 
   const days = useMemo<DayColumn[]>(() => {
     const weekStart = dayjs().startOf('week').add(1, 'day')
     const today = dayjs()
+    // Фильтр по площадкам: пост виден, если хотя бы одна из его сетей активна
+    const activeSet = new Set(activeNetworkIds)
     return Array.from({ length: 7 }, (_, i) => {
       const d = weekStart.add(i, 'day')
       return {
@@ -48,11 +53,14 @@ export function ContentPlanPage() {
         date: d.format('D MMM'),
         isToday: d.isSame(today, 'day'),
         posts: posts
-          .filter((p) => dayjs(p.scheduledAt).isSame(d, 'day'))
+          .filter(
+            (p) =>
+              dayjs(p.scheduledAt).isSame(d, 'day') && p.networkIds.some((id) => activeSet.has(id)),
+          )
           .sort((a, b) => dayjs(a.scheduledAt).valueOf() - dayjs(b.scheduledAt).valueOf()),
       }
     })
-  }, [posts])
+  }, [posts, activeNetworkIds])
 
   return (
     <Stack gap="lg">
@@ -82,6 +90,8 @@ export function ContentPlanPage() {
           </Button>
         </Group>
       </Group>
+
+      <PlatformChips />
 
       <Box style={{ overflowX: 'auto' }}>
         <SimpleGrid cols={{ base: 1, xs: 2, sm: 3, md: 7 }} spacing="xs" style={{ minWidth: 720 }}>

--- a/frontend/src/pages/content-plan/ui/PlatformChips.tsx
+++ b/frontend/src/pages/content-plan/ui/PlatformChips.tsx
@@ -1,0 +1,132 @@
+import { Box, Group, Skeleton, Text, UnstyledButton } from '@mantine/core'
+import { IconEye, IconEyeOff } from '@tabler/icons-react'
+import { NETWORKS } from '@/shared/config'
+import type { Network } from '@/shared/config'
+import { NetworkPill } from '@/shared/ui'
+import { useAppModals } from '@/features/app-modals'
+import { useCalendarFilter } from '@/features/filter-by-platform'
+import { useConnections } from '@/entities/platform-account'
+
+// Приглушённые тона неподключённой площадки — из макета app-dashboard (блок netChips)
+const MUTED_BADGE = 'rgba(23,21,15,.35)'
+const MUTED_TEXT = 'rgba(23,21,15,.5)'
+const BORDER_CONNECTED = 'rgba(23,21,15,.12)'
+const BORDER_DISCONNECTED = 'rgba(23,21,15,.25)'
+
+/**
+ * Ряд из 7 чипсов-площадок над календарём: показывает статус подключения,
+ * по клику открывает модалку «Подключение площадок», а иконка-глаз в чипсе
+ * включает/выключает площадку в фильтре постов календаря.
+ */
+export function PlatformChips() {
+  const { data: connections, isLoading, isError } = useConnections()
+  const { openConnectPlatform } = useAppModals()
+  const { isNetworkActive, toggleNetwork } = useCalendarFilter()
+
+  // Скелетоны на время «загрузки» подключений (мок отдаёт мгновенно, но форма готова к API)
+  if (isLoading) {
+    return (
+      <Group gap="xs" wrap="wrap">
+        {NETWORKS.map((network) => (
+          <Skeleton key={network.id} height={36} width={140} radius="var(--mantine-radius-pill)" />
+        ))}
+      </Group>
+    )
+  }
+
+  if (isError) {
+    return (
+      <Text size="sm" c="red">
+        Не удалось загрузить статусы площадок — обновите страницу
+      </Text>
+    )
+  }
+
+  const connectedById = new Map(connections.map((c) => [c.networkId, c.connected]))
+
+  return (
+    <Group gap="xs" wrap="wrap">
+      {NETWORKS.map((network) => (
+        <PlatformChip
+          key={network.id}
+          network={network}
+          connected={connectedById.get(network.id) ?? false}
+          filterActive={isNetworkActive(network.id)}
+          onOpen={() => openConnectPlatform()}
+          onToggleFilter={() => toggleNetwork(network.id)}
+        />
+      ))}
+    </Group>
+  )
+}
+
+interface PlatformChipProps {
+  network: Network
+  connected: boolean
+  filterActive: boolean
+  onOpen: () => void
+  onToggleFilter: () => void
+}
+
+/**
+ * Чипс площадки. Основная кнопка (бейдж + подпись) открывает модалку подключения,
+ * отдельная иконка-глаз переключает фильтр — клики не конфликтуют (кнопки не вложены).
+ */
+function PlatformChip({
+  network,
+  connected,
+  filterActive,
+  onOpen,
+  onToggleFilter,
+}: PlatformChipProps) {
+  return (
+    <Box
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        border: connected
+          ? `1.5px solid ${BORDER_CONNECTED}`
+          : `1.5px dashed ${BORDER_DISCONNECTED}`,
+        borderRadius: 'var(--mantine-radius-pill)',
+        background: connected ? 'var(--mantine-color-white)' : 'transparent',
+        paddingRight: 6,
+      }}
+    >
+      <UnstyledButton
+        onClick={onOpen}
+        title={connected ? 'Нажмите, чтобы отключить' : 'Нажмите, чтобы подключить'}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 7,
+          padding: '5px 5px 5px 6px',
+          fontSize: 12.5,
+          fontWeight: 600,
+          color: connected ? 'var(--mantine-color-text)' : MUTED_TEXT,
+        }}
+      >
+        {/* Серый бейдж неподключённой площадки — подменяем цвет сети на приглушённый */}
+        <NetworkPill
+          network={connected ? network : { ...network, color: MUTED_BADGE }}
+          variant="badge"
+        />
+        {connected ? network.name : `${network.name} — подключить`}
+      </UnstyledButton>
+      <UnstyledButton
+        onClick={onToggleFilter}
+        title={
+          filterActive ? 'Скрыть посты площадки в календаре' : 'Показать посты площадки в календаре'
+        }
+        aria-pressed={filterActive}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          padding: 3,
+          color: filterActive ? 'var(--mantine-color-brand-6)' : MUTED_BADGE,
+        }}
+      >
+        {filterActive ? <IconEye size={16} /> : <IconEyeOff size={16} />}
+      </UnstyledButton>
+    </Box>
+  )
+}

--- a/frontend/src/pages/media/ui/MediaPage.tsx
+++ b/frontend/src/pages/media/ui/MediaPage.tsx
@@ -1,42 +1,31 @@
 import { useRef, useState } from 'react'
 import {
-  Badge,
   Box,
   Button,
   Card,
   Container,
   Group,
   Modal,
-  SimpleGrid,
   Stack,
   Text,
-  ThemeIcon,
   Title,
   UnstyledButton,
 } from '@mantine/core'
 import { useDisclosure } from '@mantine/hooks'
 import { notifications } from '@mantine/notifications'
-import { IconPhoto, IconUpload, IconVideo } from '@tabler/icons-react'
-import { useMedia } from '@/entities/media'
+import { IconUpload } from '@tabler/icons-react'
+import { useMedia, MediaThumb } from '@/entities/media'
 import type { Media } from '@/entities/media'
+import { MediaGallery, MediaGallerySkeleton } from '@/widgets/media-gallery'
 import { EmptyState, QueryState, ConfirmDeleteButton } from '@/shared/ui'
 import { formatDateTime } from '@/shared/lib'
 
 const PLACEHOLDER_BG = '#F6F4EF'
 const DASHED_BORDER = '1.5px dashed rgba(23,21,15,.2)'
 
-/** Иконка-заглушка миниатюры по типу медиа. */
-function MediaThumb({ kind, size = 34 }: { kind: Media['kind']; size?: number }) {
-  const Icon = kind === 'video' ? IconVideo : IconPhoto
-  return (
-    <ThemeIcon variant="light" color="brand" size={size + 22} radius="md">
-      <Icon size={size} stroke={1.6} />
-    </ThemeIcon>
-  )
-}
-
 export function MediaPage() {
-  const { data: media, isLoading, error } = useMedia()
+  const { data, isLoading, error } = useMedia()
+  const media = data ?? []
 
   const [uploadOpened, upload] = useDisclosure(false)
   const [selected, setSelected] = useState<Media | null>(null)
@@ -58,90 +47,47 @@ export function MediaPage() {
 
   return (
     <Container size="lg" px={0}>
-      <Group align="center" gap={14} wrap="wrap" mb="lg">
-        <Title order={1} fz={{ base: 22, sm: 24 }} fw={800} style={{ letterSpacing: '-.4px' }}>
-          Медиатека
-        </Title>
-        <Box style={{ flex: 1 }} />
-        <Button
-          color="brand"
-          radius="md"
-          leftSection={<IconUpload size={17} />}
-          onClick={upload.open}
-        >
-          Загрузить
-        </Button>
-      </Group>
+      {/* Карточка медиатеки по макету: белый фон, бордер, radius 16, padding 18 */}
+      <Card withBorder radius={16} p={18} style={{ borderColor: 'rgba(23,21,15,.1)' }}>
+        <Group align="center" gap={10} wrap="wrap" mb="md">
+          <Title order={1} fz={14.5} fw={700}>
+            Фото и видео проекта
+          </Title>
+          <Box style={{ flex: 1 }} />
+          <Button
+            color="brand"
+            radius="md"
+            leftSection={<IconUpload size={17} />}
+            onClick={upload.open}
+          >
+            Загрузить
+          </Button>
+        </Group>
 
-      <QueryState isLoading={isLoading} error={error}>
-        {media.length === 0 ? (
-          <EmptyState
-            title="В медиатеке пусто"
-            description="Загрузите фото и видео, чтобы прикреплять их к постам."
-            action={
-              <Button
-                color="brand"
-                radius="md"
-                leftSection={<IconUpload size={17} />}
-                onClick={upload.open}
-              >
-                Загрузить
-              </Button>
-            }
-          />
-        ) : (
-          <SimpleGrid cols={{ base: 2, sm: 3, md: 4 }} spacing="md">
-            {media.map((item) => (
-              <Card
-                key={item.id}
-                withBorder
-                radius="lg"
-                p="sm"
-                role="button"
-                tabIndex={0}
-                onClick={() => setSelected(item)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault()
-                    setSelected(item)
-                  }
-                }}
-                style={{ borderColor: 'rgba(23,21,15,.1)', cursor: 'pointer' }}
-              >
-                <Box
-                  mb="sm"
-                  style={{
-                    aspectRatio: '4 / 3',
-                    borderRadius: 10,
-                    background: PLACEHOLDER_BG,
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                  }}
+        {/* Скелетоны сетки показываем сами, поэтому isLoading в QueryState не передаём */}
+        <QueryState isLoading={false} error={error}>
+          {isLoading ? (
+            <MediaGallerySkeleton />
+          ) : media.length === 0 ? (
+            <EmptyState
+              title="В медиатеке пусто"
+              description="Загрузите фото и видео, чтобы прикреплять их к постам."
+              action={
+                <Button
+                  color="brand"
+                  radius="md"
+                  leftSection={<IconUpload size={17} />}
+                  onClick={upload.open}
                 >
-                  <MediaThumb kind={item.kind} />
-                </Box>
-                <Text fz={13.5} fw={600} lineClamp={1} title={item.name}>
-                  {item.name}
-                </Text>
-                <Group gap={6} mt={4} justify="space-between" wrap="nowrap">
-                  <Text fz={12} c="dimmed">
-                    {item.sizeLabel}
-                  </Text>
-                  <Badge
-                    size="sm"
-                    variant="light"
-                    color={item.kind === 'video' ? 'grape' : 'brand'}
-                    styles={{ root: { textTransform: 'none', fontWeight: 600 } }}
-                  >
-                    {item.kind === 'video' ? 'Видео' : 'Фото'}
-                  </Badge>
-                </Group>
-              </Card>
-            ))}
-          </SimpleGrid>
-        )}
-      </QueryState>
+                  Загрузить
+                </Button>
+              }
+            />
+          ) : (
+            <MediaGallery media={media} onSelect={setSelected} onAdd={upload.open} />
+          )}
+        </QueryState>
+      </Card>
 
       {/* ===== Загрузка в медиатеку ===== */}
       <Modal

--- a/frontend/src/widgets/media-gallery/index.ts
+++ b/frontend/src/widgets/media-gallery/index.ts
@@ -1,0 +1,2 @@
+export { MediaGallery } from './ui/MediaGallery'
+export { MediaGallerySkeleton } from './ui/MediaGallerySkeleton'

--- a/frontend/src/widgets/media-gallery/ui/MediaGallery.module.css
+++ b/frontend/src/widgets/media-gallery/ui/MediaGallery.module.css
@@ -1,0 +1,19 @@
+/* Пунктирная плитка «+ Добавить»: синий пунктир и лёгкая заливка на hover (по макету). */
+.addTile {
+  aspect-ratio: 4 / 3;
+  border: 1.5px dashed rgba(43, 80, 236, 0.4);
+  border-radius: 12px;
+  background: transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--mantine-color-brand-6);
+  cursor: pointer;
+  transition: background 120ms ease;
+}
+
+.addTile:hover {
+  background: rgba(43, 80, 236, 0.05);
+}

--- a/frontend/src/widgets/media-gallery/ui/MediaGallery.tsx
+++ b/frontend/src/widgets/media-gallery/ui/MediaGallery.tsx
@@ -1,0 +1,58 @@
+import { Box, SimpleGrid, Text, UnstyledButton } from '@mantine/core'
+import { MediaTile } from '@/entities/media'
+import type { Media } from '@/entities/media'
+import classes from './MediaGallery.module.css'
+
+/** UPPERCASE-заголовок секции («ФОТО» / «ВИДЕО») по макету app-dashboard.html. */
+function SectionLabel({ children, mt }: { children: string; mt?: number }) {
+  return (
+    <Text
+      mt={mt}
+      fz={12}
+      fw={700}
+      tt="uppercase"
+      style={{ letterSpacing: '.5px', color: 'rgba(23,21,15,.5)' }}
+    >
+      {children}
+    </Text>
+  )
+}
+
+interface MediaGalleryProps {
+  media: Media[]
+  /** Клик по плитке — открыть предпросмотр. */
+  onSelect: (media: Media) => void
+  /** Клик по «+ Добавить» — открыть модалку загрузки. */
+  onAdd: () => void
+}
+
+/** Сетка медиатеки: секции «Фото» и «Видео» плюс пунктирная плитка «+ Добавить». */
+export function MediaGallery({ media, onSelect, onAdd }: MediaGalleryProps) {
+  const photos = media.filter((m) => m.kind === 'photo')
+  const videos = media.filter((m) => m.kind === 'video')
+
+  return (
+    <Box>
+      <SectionLabel>Фото</SectionLabel>
+      <SimpleGrid mt="xs" cols={{ base: 2, sm: 3, md: 4 }} spacing={12}>
+        {photos.map((item) => (
+          <MediaTile key={item.id} media={item} onClick={() => onSelect(item)} />
+        ))}
+        <UnstyledButton className={classes.addTile} onClick={onAdd}>
+          + Добавить
+        </UnstyledButton>
+      </SimpleGrid>
+
+      {videos.length > 0 ? (
+        <>
+          <SectionLabel mt={18}>Видео</SectionLabel>
+          <SimpleGrid mt="xs" cols={{ base: 2, sm: 3, md: 4 }} spacing={12}>
+            {videos.map((item) => (
+              <MediaTile key={item.id} media={item} onClick={() => onSelect(item)} />
+            ))}
+          </SimpleGrid>
+        </>
+      ) : null}
+    </Box>
+  )
+}

--- a/frontend/src/widgets/media-gallery/ui/MediaGallerySkeleton.tsx
+++ b/frontend/src/widgets/media-gallery/ui/MediaGallerySkeleton.tsx
@@ -1,0 +1,33 @@
+import { Box, SimpleGrid, Skeleton, Stack } from '@mantine/core'
+
+/** Скелетон одной плитки: превью 4/3 плюс две строки под имя и метаданные. */
+function TileSkeleton() {
+  return (
+    <Stack gap={6}>
+      <Skeleton radius={12} style={{ aspectRatio: '4 / 3', height: 'auto' }} />
+      <Skeleton h={12} w="70%" radius="sm" />
+      <Skeleton h={10} w="50%" radius="sm" />
+    </Stack>
+  )
+}
+
+/** Сетка скелетонов на время загрузки — каркас повторяет секции «Фото» и «Видео». */
+export function MediaGallerySkeleton() {
+  return (
+    <Box>
+      <Skeleton h={12} w={46} radius="sm" />
+      <SimpleGrid mt="xs" cols={{ base: 2, sm: 3, md: 4 }} spacing={12}>
+        {Array.from({ length: 4 }, (_, i) => (
+          <TileSkeleton key={`photo-${i}`} />
+        ))}
+      </SimpleGrid>
+
+      <Skeleton mt={18} h={12} w={54} radius="sm" />
+      <SimpleGrid mt="xs" cols={{ base: 2, sm: 3, md: 4 }} spacing={12}>
+        {Array.from({ length: 2 }, (_, i) => (
+          <TileSkeleton key={`video-${i}`} />
+        ))}
+      </SimpleGrid>
+    </Box>
+  )
+}


### PR DESCRIPTION
Closes #201

Стек: после PR #190-project-switcher.

- PlatformChips: 7 чипсов в порядке NETWORKS; подключённая — белый фон/сплошная граница/имя, неподключённая — пунктир + «<Имя> — подключить»; клик по чипсу открывает модалку подключения
- Фильтр — отдельная кнопка-глаз (IconEye/IconEyeOff) в чипсе, aria-pressed, кнопки не вложены (в макете весь чипс — модалка, отдельный элемент фильтра — прямое требование issue)
- features/filter-by-platform: slice calendarFilter (activeNetworkIds, toggleNetwork) + hook; редьюсер подключён в стор; посты календаря фильтруются по активным сетям
- useConnections переведён на useQuery (connectionKeys, initialData, staleTime Infinity) с сохранением интерфейса; loading — 7 Skeleton-пилюль, error — текст

Проверено: lint/tsc/build чисто; в живом календаре оба состояния чипсов на месте, фильтр работает (SSR-прогон агента: 8 постов → 2 при фильтре «только Дзен»).