### PR TITLE
feat(frontend): шапка маркетинга — активный пункт, бургер с Drawer, якоря на главную

### DIFF
--- a/frontend/src/pages/feature-ai/ui/AiFeaturePage.tsx
+++ b/frontend/src/pages/feature-ai/ui/AiFeaturePage.tsx
@@ -53,7 +53,7 @@ export function AiFeaturePage() {
 
   return (
     <Box>
-      <MarketingHeader />
+      <MarketingHeader active="features" />
 
       {/* Хлебные крошки */}
       <Container size="lg" pt={24} pb={0}>
@@ -94,7 +94,11 @@ export function AiFeaturePage() {
               style={{ letterSpacing: '-0.5px', textWrap: 'balance' }}
             >
               ИИ{' '}
-              <Box component="span" px={8} style={{ background: 'var(--mantine-color-accent-5)', borderRadius: 8 }}>
+              <Box
+                component="span"
+                px={8}
+                style={{ background: 'var(--mantine-color-accent-5)', borderRadius: 8 }}
+              >
                 пишет
               </Box>{' '}
               — вы публикуете

--- a/frontend/src/pages/feature-autoposting/ui/AutopostingPage.tsx
+++ b/frontend/src/pages/feature-autoposting/ui/AutopostingPage.tsx
@@ -108,7 +108,7 @@ export function AutopostingPage() {
 
   return (
     <Box style={{ background: '#F6F4EF', color: '#17150F' }}>
-      <MarketingHeader />
+      <MarketingHeader active="features" />
 
       {/* Хлебные крошки */}
       <Container size="lg" pt={{ base: 20, sm: 28 }}>
@@ -153,7 +153,11 @@ export function AutopostingPage() {
                 style={{ letterSpacing: '-.7px', textWrap: 'balance' }}
               >
                 Посты выходят по расписанию —{' '}
-                <Box component="span" px={8} style={{ background: 'var(--mantine-color-accent-5)', borderRadius: 8 }}>
+                <Box
+                  component="span"
+                  px={8}
+                  style={{ background: 'var(--mantine-color-accent-5)', borderRadius: 8 }}
+                >
                   без вас
                 </Box>
               </Title>

--- a/frontend/src/pages/feature-crossposting/ui/CrosspostingPage.tsx
+++ b/frontend/src/pages/feature-crossposting/ui/CrosspostingPage.tsx
@@ -50,7 +50,7 @@ export function CrosspostingPage() {
 
   return (
     <>
-      <MarketingHeader />
+      <MarketingHeader active="features" />
 
       <Box component="main">
         {/* Хлебные крошки */}

--- a/frontend/src/pages/landing/ui/LandingPage.tsx
+++ b/frontend/src/pages/landing/ui/LandingPage.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
 import { MarketingHeader } from '@/widgets/marketing-header'
 import { MarketingFooter } from '@/widgets/marketing-footer'
 import { HeroSection } from './sections/HeroSection'
@@ -14,6 +16,16 @@ import { CtaSection } from './sections/CtaSection'
 
 /** Публичная главная страница-лендинг «Отложки». */
 export function LandingPage() {
+  const location = useLocation()
+
+  // Якорная навигация: ссылки вида /#features работают с любой страницы —
+  // после перехода скроллим к секции по id из хэша (location.key учитывает
+  // повторный клик по тому же пункту меню)
+  useEffect(() => {
+    if (!location.hash) return
+    document.getElementById(location.hash.slice(1))?.scrollIntoView({ behavior: 'smooth' })
+  }, [location.hash, location.key])
+
   return (
     <>
       <MarketingHeader />

--- a/frontend/src/pages/pricing/ui/PricingPage.tsx
+++ b/frontend/src/pages/pricing/ui/PricingPage.tsx
@@ -159,7 +159,7 @@ export function PricingPage() {
 
   return (
     <Box style={{ background: '#F6F4EF', color: INK }}>
-      <MarketingHeader />
+      <MarketingHeader active="pricing" />
 
       {/* Hero: заголовок, подзаголовок и переключатель периода */}
       <Box component="section">

--- a/frontend/src/widgets/marketing-footer/ui/MarketingFooter.tsx
+++ b/frontend/src/widgets/marketing-footer/ui/MarketingFooter.tsx
@@ -97,6 +97,9 @@ export function MarketingFooter() {
             <Anchor component={Link} to="/legal#privacy" c="dimmed" fz={13} underline="never">
               Политика конфиденциальности
             </Anchor>
+            <Anchor component={Link} to="/app" c="dimmed" fz={13} underline="never">
+              Личный кабинет
+            </Anchor>
           </Group>
         </Group>
       </Container>

--- a/frontend/src/widgets/marketing-header/index.ts
+++ b/frontend/src/widgets/marketing-header/index.ts
@@ -1,1 +1,2 @@
 export { MarketingHeader } from './ui/MarketingHeader'
+export type { MarketingNavId } from './ui/MarketingHeader'

--- a/frontend/src/widgets/marketing-header/ui/MarketingHeader.tsx
+++ b/frontend/src/widgets/marketing-header/ui/MarketingHeader.tsx
@@ -1,25 +1,57 @@
-import { Anchor, Box, Button, Container, Group } from '@mantine/core'
+import {
+  Anchor,
+  Box,
+  Burger,
+  Button,
+  Container,
+  Divider,
+  Drawer,
+  Group,
+  Stack,
+} from '@mantine/core'
+import { useDisclosure } from '@mantine/hooks'
 import { Link } from 'react-router-dom'
 import { Logo } from '@/shared/ui'
 import { useAuthModal } from '@/features/auth'
 
+/** Идентификатор пункта меню, который страница может подсветить как активный. */
+export type MarketingNavId = 'features' | 'how' | 'networks' | 'pricing' | 'faq'
+
 interface NavItem {
+  id: MarketingNavId
   label: string
-  href?: string
-  to?: string
+  /** Путь для react-router: якорные пункты ведут на главную (/#anchor) с любой страницы. */
+  to: string
 }
 
 const NAV: NavItem[] = [
-  { label: 'Возможности', href: '#features' },
-  { label: 'Как это работает', href: '#how' },
-  { label: 'Соцсети', href: '#networks' },
-  { label: 'Тарифы', to: '/pricing' },
-  { label: 'FAQ', href: '#faq' },
+  { id: 'features', label: 'Возможности', to: '/#features' },
+  { id: 'how', label: 'Как это работает', to: '/#how' },
+  { id: 'networks', label: 'Соцсети', to: '/#networks' },
+  { id: 'pricing', label: 'Тарифы', to: '/pricing' },
+  { id: 'faq', label: 'FAQ', to: '/#faq' },
 ]
 
-/** Липкая шапка маркетинг-сайта: логотип, якорная навигация, кнопки входа. */
-export function MarketingHeader() {
+/** Цвета пунктов меню из макета: активный — тёмный и жирный, остальные приглушённые. */
+const NAV_ACTIVE_COLOR = '#17150F'
+const NAV_COLOR = 'rgba(23,21,15,0.65)'
+
+interface MarketingHeaderProps {
+  /** Активный пункт меню (подсвечивается тёмным и жирным); без пропа активного пункта нет. */
+  active?: MarketingNavId
+}
+
+/** Липкая шапка маркетинг-сайта: логотип, навигация (на мобильном — бургер с Drawer), кнопки входа. */
+export function MarketingHeader({ active }: MarketingHeaderProps) {
   const { open } = useAuthModal()
+  const [menuOpened, { toggle: toggleMenu, close: closeMenu }] = useDisclosure(false)
+
+  // закрыть мобильное меню и открыть модалку входа/регистрации
+  const openAuth = (mode: 'login' | 'register') => {
+    closeMenu()
+    open(mode)
+  }
+
   return (
     <Box
       component="header"
@@ -39,32 +71,19 @@ export function MarketingHeader() {
               <Logo />
             </Anchor>
             <Group gap="lg" visibleFrom="sm">
-              {NAV.map((item) =>
-                item.to ? (
-                  <Anchor
-                    key={item.label}
-                    component={Link}
-                    to={item.to}
-                    underline="never"
-                    fw={600}
-                    fz={14}
-                    c="rgba(23,21,15,0.65)"
-                  >
-                    {item.label}
-                  </Anchor>
-                ) : (
-                  <Anchor
-                    key={item.label}
-                    href={item.href}
-                    underline="never"
-                    fw={600}
-                    fz={14}
-                    c="rgba(23,21,15,0.65)"
-                  >
-                    {item.label}
-                  </Anchor>
-                ),
-              )}
+              {NAV.map((item) => (
+                <Anchor
+                  key={item.id}
+                  component={Link}
+                  to={item.to}
+                  underline="never"
+                  fw={item.id === active ? 700 : 600}
+                  fz={14}
+                  c={item.id === active ? NAV_ACTIVE_COLOR : NAV_COLOR}
+                >
+                  {item.label}
+                </Anchor>
+              ))}
             </Group>
           </Group>
           <Group gap="sm" wrap="nowrap">
@@ -72,17 +91,57 @@ export function MarketingHeader() {
               variant="subtle"
               color="dark"
               size="sm"
-              visibleFrom="xs"
+              visibleFrom="sm"
               onClick={() => open('login')}
             >
               Войти
             </Button>
-            <Button size="sm" onClick={() => open('register')}>
+            <Button size="sm" visibleFrom="xs" onClick={() => open('register')}>
               Попробовать бесплатно
             </Button>
+            <Burger
+              opened={menuOpened}
+              onClick={toggleMenu}
+              hiddenFrom="sm"
+              size="sm"
+              aria-label="Открыть меню"
+            />
           </Group>
         </Group>
       </Container>
+
+      {/* Мобильное меню: все пункты навигации + кнопки входа */}
+      <Drawer
+        opened={menuOpened}
+        onClose={closeMenu}
+        position="right"
+        size="xs"
+        hiddenFrom="sm"
+        title={<Logo />}
+      >
+        <Stack gap="xs">
+          {NAV.map((item) => (
+            <Anchor
+              key={item.id}
+              component={Link}
+              to={item.to}
+              underline="never"
+              fw={item.id === active ? 700 : 600}
+              fz={16}
+              py={6}
+              c={item.id === active ? NAV_ACTIVE_COLOR : NAV_COLOR}
+              onClick={closeMenu}
+            >
+              {item.label}
+            </Anchor>
+          ))}
+          <Divider my="xs" />
+          <Button variant="default" color="dark" onClick={() => openAuth('login')}>
+            Войти
+          </Button>
+          <Button onClick={() => openAuth('register')}>Попробовать бесплатно</Button>
+        </Stack>
+      </Drawer>
     </Box>
   )
 }


### PR DESCRIPTION
Closes #180

Стек: после PR #185-pricing-faq.

- MarketingHeader: проп `active` ('features'|'pricing'|…) — активный пункт #17150F/fw700, остальные приглушены; прокинут на 3 страницах фич и тарифах
- Мобильный бургер: Burger (hiddenFrom=sm) + Drawer справа со всеми пунктами и кнопками «Войти»/«Попробовать бесплатно»; клик закрывает Drawer
- Якорные пункты → Link на /#features|/#how|/#networks|/#faq; в LandingPage — scrollIntoView по location.hash (+location.key — повторный клик работает); якоря доступны с любой страницы
- В футер добавлена ссылка «Личный кабинет» → /app (есть в макете; неавторизованного уведёт гард) — легко откатить, если не нужна

Решение по мобильной шапке: на <576px обе кнопки уходят в Drawer (логотип+бургер, без горизонтального скролла на 375px — проверено).

Проверено: lint/tsc/build чисто; живой прогон — fw=700 у активного пункта, Drawer открывается, 375px без h-скролла.