### PR TITLE
feat(frontend): лендинг — демо ИИ, showCompetitors, иконки FAQ, scroll-margin

### DIFF
--- a/frontend/src/features/auth/api/mockAuthApi.ts
+++ b/frontend/src/features/auth/api/mockAuthApi.ts
@@ -1,0 +1,63 @@
+/**
+ * Мок-API авторизации: бэкенда пока нет, поэтому «запросы» эмулируются
+ * задержкой ~600мс. Ошибки триггерятся заранее заданными значениями (см.
+ * константы ниже) — так можно вручную проверить состояния loading/error.
+ * Реальные POST /auth/login, /auth/register, /auth/password-reset и
+ * сгенерированный клиент — отдельные задачи (#110, #147).
+ */
+
+/** Задержка мок-запроса, мс */
+const MOCK_DELAY_MS = 600
+
+/** Пароль-триггер ошибки входа: `wrong` → «неверная почта или пароль» */
+export const MOCK_WRONG_PASSWORD = 'wrong'
+
+/** Email-триггер ошибки регистрации: почта «уже занята» */
+export const MOCK_TAKEN_EMAIL = 'taken@example.ru'
+
+/** Email-триггер ошибки сброса пароля: аккаунт «не найден» */
+export const MOCK_UNKNOWN_EMAIL = 'unknown@example.ru'
+
+const wait = () => new Promise((resolve) => setTimeout(resolve, MOCK_DELAY_MS))
+
+export interface LoginPayload {
+  email: string
+  password: string
+  /** Значение чекбокса «Запомнить меня» — прокидывается уже сейчас, чтобы контракт был готов к реальному API */
+  rememberMe: boolean
+}
+
+/** Мок POST /auth/login */
+export async function mockLogin({ password }: LoginPayload): Promise<void> {
+  await wait()
+  if (password === MOCK_WRONG_PASSWORD) {
+    throw new Error('Неверная почта или пароль. Проверьте данные и попробуйте ещё раз.')
+  }
+}
+
+export interface RegisterPayload {
+  name: string
+  email: string
+  password: string
+}
+
+/** Мок POST /auth/register */
+export async function mockRegister({ email }: RegisterPayload): Promise<void> {
+  await wait()
+  if (email === MOCK_TAKEN_EMAIL) {
+    throw new Error('Эта почта уже зарегистрирована — попробуйте войти.')
+  }
+}
+
+/** Мок POST /auth/password-reset */
+export async function mockRequestPasswordReset(email: string): Promise<void> {
+  await wait()
+  if (email === MOCK_UNKNOWN_EMAIL) {
+    throw new Error('Не нашли аккаунт с такой почтой. Проверьте адрес или зарегистрируйтесь.')
+  }
+}
+
+/** Достаём текст ошибки из мок-запроса (на будущее — из ответа API) */
+export function getAuthErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'Что-то пошло не так. Попробуйте ещё раз.'
+}

--- a/frontend/src/features/auth/ui/AuthModal.tsx
+++ b/frontend/src/features/auth/ui/AuthModal.tsx
@@ -13,7 +13,7 @@ const COPY: Record<AuthMode, { title: string; subtitle: string }> = {
   },
   register: {
     title: 'Создайте аккаунт',
-    subtitle: 'Бесплатный тариф навсегда. Карта не нужна.',
+    subtitle: 'Бесплатный тариф навсегда: 3 соцсети и 10 постов в месяц. Карта не нужна.',
   },
   reset: {
     title: 'Восстановим пароль',
@@ -41,16 +41,19 @@ export function AuthModal() {
       title={null}
     >
       <Stack gap="xs">
-        <SegmentedControl
-          fullWidth
-          color="dark"
-          value={mode === 'register' ? 'register' : 'login'}
-          onChange={(v) => setMode(v as AuthMode)}
-          data={[
-            { label: 'Вход', value: 'login' },
-            { label: 'Регистрация', value: 'register' },
-          ]}
-        />
+        {/* Вкладки — только в режимах входа/регистрации: в режиме сброса их нет (как в макете) */}
+        {isAuth && (
+          <SegmentedControl
+            fullWidth
+            color="dark"
+            value={mode === 'register' ? 'register' : 'login'}
+            onChange={(v) => setMode(v as AuthMode)}
+            data={[
+              { label: 'Вход', value: 'login' },
+              { label: 'Регистрация', value: 'register' },
+            ]}
+          />
+        )}
 
         <div>
           <Title order={3} fz={18} fw={800}>

--- a/frontend/src/features/auth/ui/LoginForm.tsx
+++ b/frontend/src/features/auth/ui/LoginForm.tsx
@@ -1,8 +1,20 @@
-import { Anchor, Button, Checkbox, Group, PasswordInput, Stack, TextInput } from '@mantine/core'
+import { useState } from 'react'
+import {
+  Alert,
+  Anchor,
+  Button,
+  Checkbox,
+  Group,
+  PasswordInput,
+  Stack,
+  TextInput,
+} from '@mantine/core'
+import { IconAlertCircle } from '@tabler/icons-react'
 import { useForm } from '@mantine/form'
 import { useDispatch } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
 import { login } from '@/entities/session'
+import { getAuthErrorMessage, mockLogin } from '../api/mockAuthApi'
 import { useAuthModal } from '../model/hooks'
 
 interface LoginValues {
@@ -16,6 +28,10 @@ export function LoginForm() {
   const dispatch = useDispatch()
   const navigate = useNavigate()
 
+  // Состояния мок-запроса: спиннер в кнопке + блокировка полей, ошибка — в Alert
+  const [pending, setPending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
   const form = useForm<LoginValues>({
     initialValues: { email: '', password: '', remember: false },
     validate: {
@@ -24,11 +40,24 @@ export function LoginForm() {
     },
   })
 
-  const submit = form.onSubmit(() => {
-    // TODO (Design First): POST /auth/login (email + password, remember-me), issue #110. Пока мок.
-    dispatch(login())
-    close()
-    navigate('/app/calendar')
+  const submit = form.onSubmit(async (values) => {
+    setError(null)
+    setPending(true)
+    try {
+      // Мок вместо POST /auth/login (#110): «Запомнить меня» уже прокидывается как rememberMe
+      await mockLogin({
+        email: values.email,
+        password: values.password,
+        rememberMe: values.remember,
+      })
+      dispatch(login())
+      close()
+      navigate('/app/calendar')
+    } catch (e) {
+      setError(getAuthErrorMessage(e))
+    } finally {
+      setPending(false)
+    }
   })
 
   return (
@@ -38,26 +67,34 @@ export function LoginForm() {
           label="Почта"
           placeholder="you@example.ru"
           withAsterisk
+          disabled={pending}
           {...form.getInputProps('email')}
         />
         <PasswordInput
           label="Пароль"
           placeholder="••••••••"
           withAsterisk
+          disabled={pending}
           {...form.getInputProps('password')}
         />
         <Group justify="space-between">
           <Checkbox
             label="Запомнить меня"
+            disabled={pending}
             {...form.getInputProps('remember', { type: 'checkbox' })}
           />
           <Anchor component="button" type="button" size="sm" onClick={() => setMode('reset')}>
             Забыли пароль?
           </Anchor>
         </Group>
-        <Button type="submit" fullWidth mt={2}>
+        <Button type="submit" fullWidth mt={2} loading={pending}>
           Войти
         </Button>
+        {error && (
+          <Alert color="red" icon={<IconAlertCircle size={18} />}>
+            {error}
+          </Alert>
+        )}
       </Stack>
     </form>
   )

--- a/frontend/src/features/auth/ui/RegisterForm.tsx
+++ b/frontend/src/features/auth/ui/RegisterForm.tsx
@@ -1,8 +1,11 @@
-import { Anchor, Button, Checkbox, PasswordInput, Stack, TextInput } from '@mantine/core'
+import { useState } from 'react'
+import { Alert, Anchor, Button, Checkbox, PasswordInput, Stack, TextInput } from '@mantine/core'
+import { IconAlertCircle } from '@tabler/icons-react'
 import { useForm } from '@mantine/form'
 import { useDispatch } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
 import { login } from '@/entities/session'
+import { getAuthErrorMessage, mockRegister } from '../api/mockAuthApi'
 import { useAuthModal } from '../model/hooks'
 
 interface RegisterValues {
@@ -17,6 +20,10 @@ export function RegisterForm() {
   const dispatch = useDispatch()
   const navigate = useNavigate()
 
+  // Состояния мок-запроса: спиннер в кнопке + блокировка полей, ошибка — в Alert
+  const [pending, setPending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
   const form = useForm<RegisterValues>({
     initialValues: { name: '', email: '', password: '', oferta: false },
     validate: {
@@ -27,11 +34,20 @@ export function RegisterForm() {
     },
   })
 
-  const submit = form.onSubmit(() => {
-    // TODO (Design First): POST /auth/register + провижининг free-тарифа, issue #110. Пока мок.
-    dispatch(login())
-    close()
-    navigate('/app/calendar')
+  const submit = form.onSubmit(async (values) => {
+    setError(null)
+    setPending(true)
+    try {
+      // Мок вместо POST /auth/register + провижининг free-тарифа (#110)
+      await mockRegister({ name: values.name, email: values.email, password: values.password })
+      dispatch(login())
+      close()
+      navigate('/app/calendar')
+    } catch (e) {
+      setError(getAuthErrorMessage(e))
+    } finally {
+      setPending(false)
+    }
   })
 
   return (
@@ -41,38 +57,48 @@ export function RegisterForm() {
           label="Как вас зовут"
           placeholder="Мария"
           withAsterisk
+          disabled={pending}
           {...form.getInputProps('name')}
         />
         <TextInput
           label="Почта"
           placeholder="you@example.ru"
           withAsterisk
+          disabled={pending}
           {...form.getInputProps('email')}
         />
         <PasswordInput
           label="Пароль"
           placeholder="••••••••"
           withAsterisk
+          disabled={pending}
           {...form.getInputProps('password')}
         />
         <Checkbox
+          disabled={pending}
           {...form.getInputProps('oferta', { type: 'checkbox' })}
           label={
             <>
               Принимаю{' '}
-              <Anchor href="/legal" target="_blank">
+              <Anchor href="/legal#oferta" target="_blank">
                 оферту
               </Anchor>{' '}
               и{' '}
-              <Anchor href="/legal" target="_blank">
+              <Anchor href="/legal#privacy" target="_blank">
                 политику конфиденциальности
               </Anchor>
             </>
           }
         />
-        <Button type="submit" fullWidth mt={2}>
+        {/* Кнопка неактивна, пока не отмечен чекбокс согласия с офертой */}
+        <Button type="submit" fullWidth mt={2} disabled={!form.values.oferta} loading={pending}>
           Создать аккаунт
         </Button>
+        {error && (
+          <Alert color="red" icon={<IconAlertCircle size={18} />}>
+            {error}
+          </Alert>
+        )}
       </Stack>
     </form>
   )

--- a/frontend/src/features/auth/ui/ResetForm.tsx
+++ b/frontend/src/features/auth/ui/ResetForm.tsx
@@ -1,7 +1,8 @@
-import { Alert, Button, Stack, TextInput } from '@mantine/core'
-import { IconMailCheck } from '@tabler/icons-react'
-import { useForm } from '@mantine/form'
 import { useState } from 'react'
+import { Alert, Button, Stack, TextInput } from '@mantine/core'
+import { IconAlertCircle, IconMailCheck } from '@tabler/icons-react'
+import { useForm } from '@mantine/form'
+import { getAuthErrorMessage, mockRequestPasswordReset } from '../api/mockAuthApi'
 
 interface ResetValues {
   email: string
@@ -10,6 +11,10 @@ interface ResetValues {
 export function ResetForm() {
   const [sent, setSent] = useState(false)
 
+  // Состояния мок-запроса: спиннер в кнопке + блокировка поля, ошибка — в Alert
+  const [pending, setPending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
   const form = useForm<ResetValues>({
     initialValues: { email: '' },
     validate: {
@@ -17,16 +22,25 @@ export function ResetForm() {
     },
   })
 
-  const submit = form.onSubmit(() => {
-    // TODO (Design First): POST /auth/password-reset (email), issue #110. Пока заглушка.
-    setSent(true)
+  const submit = form.onSubmit(async (values) => {
+    setError(null)
+    setPending(true)
+    try {
+      // Мок вместо POST /auth/password-reset (#110)
+      await mockRequestPasswordReset(values.email)
+      setSent(true)
+    } catch (e) {
+      setError(getAuthErrorMessage(e))
+    } finally {
+      setPending(false)
+    }
   })
 
   if (sent) {
     return (
       <Stack gap="sm">
         <Alert color="green" icon={<IconMailCheck size={18} />} title="Ссылка отправлена.">
-          Проверьте почту — там ссылка для сброса пароля.
+          Проверьте входящие — а если письма нет, загляните в «Спам».
         </Alert>
         <Button variant="light" fullWidth onClick={() => setSent(false)}>
           Отправить ещё раз
@@ -42,11 +56,17 @@ export function ResetForm() {
           label="Почта"
           placeholder="you@example.ru"
           withAsterisk
+          disabled={pending}
           {...form.getInputProps('email')}
         />
-        <Button type="submit" fullWidth mt={4}>
+        <Button type="submit" fullWidth mt={4} loading={pending}>
           Отправить ссылку
         </Button>
+        {error && (
+          <Alert color="red" icon={<IconAlertCircle size={18} />}>
+            {error}
+          </Alert>
+        )}
       </Stack>
     </form>
   )

--- a/frontend/src/pages/landing/ui/LandingPage.tsx
+++ b/frontend/src/pages/landing/ui/LandingPage.tsx
@@ -35,7 +35,7 @@ export function LandingPage() {
       <FeaturesSection />
       <CrosspostingSection />
       <AiAssistantSection />
-      <ComparisonSection />
+      <ComparisonSection showCompetitors />
       <TestimonialsSection />
       <PricingTeaserSection />
       <FaqSection />

--- a/frontend/src/pages/landing/ui/Section.tsx
+++ b/frontend/src/pages/landing/ui/Section.tsx
@@ -13,7 +13,8 @@ interface SectionProps {
 /** Обёртка секции лендинга: единый ритм (вертикальные отступы, контейнер, eyebrow/заголовок). */
 export function Section({ id, eyebrow, title, subtitle, bg, children }: SectionProps) {
   return (
-    <Box component="section" id={id} style={{ background: bg }} py={64}>
+    // scrollMarginTop: при переходе по якорю заголовок не прячется под липкую 64px-шапку
+    <Box component="section" id={id} style={{ background: bg, scrollMarginTop: 72 }} py={64}>
       <Container size="lg">
         <Stack gap="md">
           {(eyebrow || title || subtitle) && (

--- a/frontend/src/pages/landing/ui/sections/AiAssistantSection.tsx
+++ b/frontend/src/pages/landing/ui/sections/AiAssistantSection.tsx
@@ -1,15 +1,24 @@
+import { useState } from 'react'
 import { Box, Button, Card, Divider, Group, Stack, Text, Title } from '@mantine/core'
-import { Link } from 'react-router-dom'
 import { NetworkPill } from '@/shared/ui'
 import { NETWORKS } from '@/shared/config'
 import { Section } from '../Section'
 
-/** Пример поста, сгенерированного ИИ (вариант 1 из демо макета). */
-const AI_SAMPLE_TEXT =
-  'Открываем запись на декабрь! Успейте забронировать любимое время — в прошлом месяце окошки закончились за три дня.'
+/** Заготовленные варианты «сгенерированных» постов — дословно из демо макета. */
+const AI_VARIANTS = [
+  'Открываем запись на декабрь! Успейте забронировать любимое время — в прошлом месяце окошки закончились за три дня.',
+  'Секрет идеального капучино — молоко 3,2% и ровно 55 градусов. Приходите, покажем. И нальём.',
+  'Итоги недели: 4 новых вкуса, 120 довольных гостей и один очень счастливый бариста.',
+  'Совет дня: планируйте посты с вечера — утром голова нужна для важных дел.',
+]
 
 /** Спотлайт ИИ-помощника: панель с примером сгенерированного поста и ценностными тезисами. */
 export function AiAssistantSection() {
+  // Живое демо: перебор заготовленных вариантов по кругу. Сейчас это чисто
+  // клиентская симуляция — позже кнопка может дёргать реальную ручку ИИ.
+  const [variantIndex, setVariantIndex] = useState(0)
+  const nextVariant = () => setVariantIndex((index) => (index + 1) % AI_VARIANTS.length)
+
   return (
     <Section id="ai">
       <Card withBorder radius={20} p={0} style={{ overflow: 'hidden' }}>
@@ -32,11 +41,11 @@ export function AiAssistantSection() {
               Отредактируйте и отправьте в отложку — или сразу во все сети.
             </Text>
             <Group mt={24} gap={14} align="center">
-              <Button component={Link} to="/login" color="brand" radius="md" size="md">
+              <Button color="brand" radius="md" size="md" onClick={nextVariant}>
                 Предложить пост
               </Button>
               <Text fz={12.5} c="dimmed">
-                вариант 1 из 4 · живое демо
+                вариант {variantIndex + 1} из {AI_VARIANTS.length} · живое демо
               </Text>
             </Group>
           </Stack>
@@ -77,7 +86,7 @@ export function AiAssistantSection() {
               </Group>
 
               <Text mt={12} fz={14} style={{ lineHeight: 1.55 }}>
-                {AI_SAMPLE_TEXT}
+                {AI_VARIANTS[variantIndex]}
               </Text>
 
               <Divider mt={14} variant="dashed" />

--- a/frontend/src/pages/landing/ui/sections/ComparisonSection.tsx
+++ b/frontend/src/pages/landing/ui/sections/ComparisonSection.tsx
@@ -92,7 +92,14 @@ const ROWS: CompareRow[] = [
 
 const COMPETITORS = ['SMMplanner', 'PlanerMax', 'LiveDune'] as const
 
-export function ComparisonSection() {
+interface ComparisonSectionProps {
+  /** Показывать ли секцию сравнения с конкурентами; при false секция скрыта целиком. */
+  showCompetitors?: boolean
+}
+
+export function ComparisonSection({ showCompetitors = true }: ComparisonSectionProps) {
+  if (!showCompetitors) return null
+
   return (
     <Section
       id="comparison"

--- a/frontend/src/pages/landing/ui/sections/CrosspostingSection.tsx
+++ b/frontend/src/pages/landing/ui/sections/CrosspostingSection.tsx
@@ -24,7 +24,12 @@ export function CrosspostingSection() {
             <Center
               w={36}
               h={36}
-              style={{ borderRadius: 'var(--mantine-radius-pill)', background: 'var(--mantine-color-accent-5)', fontWeight: 800, fontSize: 15 }}
+              style={{
+                borderRadius: 'var(--mantine-radius-pill)',
+                background: 'var(--mantine-color-accent-5)',
+                fontWeight: 800,
+                fontSize: 15,
+              }}
             >
               М
             </Center>

--- a/frontend/src/pages/landing/ui/sections/FaqSection.tsx
+++ b/frontend/src/pages/landing/ui/sections/FaqSection.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { Accordion, Box, Text } from '@mantine/core'
 import { Section } from '../Section'
 
@@ -28,15 +29,47 @@ const FAQ_ITEMS = [
   },
 ]
 
+/** Круглый значок из макета: «−» у раскрытого пункта, «+» у свёрнутых. */
+function FaqIcon({ open }: { open: boolean }) {
+  return (
+    <Box
+      style={{
+        width: 26,
+        height: 26,
+        borderRadius: 'var(--mantine-radius-pill)',
+        border: '1.5px solid rgba(23,21,15,.2)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: 15,
+        color: 'rgba(23,21,15,.6)',
+        flex: 'none',
+      }}
+    >
+      {open ? '−' : '+'}
+    </Box>
+  )
+}
+
 /** FAQ: аккордеон с частыми вопросами, по умолчанию открыт первый. */
 export function FaqSection() {
+  // управляемое значение нужно, чтобы значок каждого пункта знал, раскрыт ли он
+  const [opened, setOpened] = useState<string | null>('0')
+
   return (
     <Section id="faq" eyebrow="FAQ" title="Частые вопросы">
       <Box maw={760} mx="auto" w="100%">
-        <Accordion defaultValue="0" variant="default" chevronPosition="right">
+        <Accordion
+          value={opened}
+          onChange={setOpened}
+          variant="default"
+          chevronPosition="right"
+          chevronSize={26}
+          disableChevronRotation
+        >
           {FAQ_ITEMS.map((item, index) => (
             <Accordion.Item key={item.q} value={String(index)}>
-              <Accordion.Control>
+              <Accordion.Control chevron={<FaqIcon open={opened === String(index)} />}>
                 <Text fw={600} fz={16} c="#17150F">
                   {item.q}
                 </Text>

--- a/frontend/src/pages/landing/ui/sections/HeroSection.tsx
+++ b/frontend/src/pages/landing/ui/sections/HeroSection.tsx
@@ -115,7 +115,11 @@ export function HeroSection() {
               style={{ letterSpacing: '-.8px', textWrap: 'balance' }}
             >
               Посты выходят{' '}
-              <Box component="span" px={8} style={{ background: 'var(--mantine-color-accent-5)', borderRadius: 8 }}>
+              <Box
+                component="span"
+                px={8}
+                style={{ background: 'var(--mantine-color-accent-5)', borderRadius: 8 }}
+              >
                 сами
               </Box>{' '}
               — даже когда вы спите


### PR DESCRIPTION
Closes #181

Стек: после PR #180-marketing-header.

- Демо ИИ: 4 варианта текста из макета, кнопка «Предложить пост» перебирает по кругу, подпись «вариант N из 4 · живое демо»
- ComparisonSection: проп `showCompetitors` (default true), при false секция скрывается
- FAQ лендинга: управляемый Accordion, первый пункт открыт, кастомный значок «+/−» в круге (chevron + disableChevronRotation)
- Section: scrollMarginTop 72 — заголовки не прячутся под 64px-шапкой при якорных переходах

Проверено: lint/tsc/build чисто; живой прогон — перебор вариантов 2→3 подтверждён кликами.