### PR TITLE
feat(frontend): вход — гейт вкладок, loading/error, disabled до оферты, тексты макета

### DIFF
--- a/frontend/src/features/auth/api/mockAuthApi.ts
+++ b/frontend/src/features/auth/api/mockAuthApi.ts
@@ -1,0 +1,63 @@
+/**
+ * Мок-API авторизации: бэкенда пока нет, поэтому «запросы» эмулируются
+ * задержкой ~600мс. Ошибки триггерятся заранее заданными значениями (см.
+ * константы ниже) — так можно вручную проверить состояния loading/error.
+ * Реальные POST /auth/login, /auth/register, /auth/password-reset и
+ * сгенерированный клиент — отдельные задачи (#110, #147).
+ */
+
+/** Задержка мок-запроса, мс */
+const MOCK_DELAY_MS = 600
+
+/** Пароль-триггер ошибки входа: `wrong` → «неверная почта или пароль» */
+export const MOCK_WRONG_PASSWORD = 'wrong'
+
+/** Email-триггер ошибки регистрации: почта «уже занята» */
+export const MOCK_TAKEN_EMAIL = 'taken@example.ru'
+
+/** Email-триггер ошибки сброса пароля: аккаунт «не найден» */
+export const MOCK_UNKNOWN_EMAIL = 'unknown@example.ru'
+
+const wait = () => new Promise((resolve) => setTimeout(resolve, MOCK_DELAY_MS))
+
+export interface LoginPayload {
+  email: string
+  password: string
+  /** Значение чекбокса «Запомнить меня» — прокидывается уже сейчас, чтобы контракт был готов к реальному API */
+  rememberMe: boolean
+}
+
+/** Мок POST /auth/login */
+export async function mockLogin({ password }: LoginPayload): Promise<void> {
+  await wait()
+  if (password === MOCK_WRONG_PASSWORD) {
+    throw new Error('Неверная почта или пароль. Проверьте данные и попробуйте ещё раз.')
+  }
+}
+
+export interface RegisterPayload {
+  name: string
+  email: string
+  password: string
+}
+
+/** Мок POST /auth/register */
+export async function mockRegister({ email }: RegisterPayload): Promise<void> {
+  await wait()
+  if (email === MOCK_TAKEN_EMAIL) {
+    throw new Error('Эта почта уже зарегистрирована — попробуйте войти.')
+  }
+}
+
+/** Мок POST /auth/password-reset */
+export async function mockRequestPasswordReset(email: string): Promise<void> {
+  await wait()
+  if (email === MOCK_UNKNOWN_EMAIL) {
+    throw new Error('Не нашли аккаунт с такой почтой. Проверьте адрес или зарегистрируйтесь.')
+  }
+}
+
+/** Достаём текст ошибки из мок-запроса (на будущее — из ответа API) */
+export function getAuthErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'Что-то пошло не так. Попробуйте ещё раз.'
+}

--- a/frontend/src/features/auth/ui/AuthModal.tsx
+++ b/frontend/src/features/auth/ui/AuthModal.tsx
@@ -13,7 +13,7 @@ const COPY: Record<AuthMode, { title: string; subtitle: string }> = {
   },
   register: {
     title: 'Создайте аккаунт',
-    subtitle: 'Бесплатный тариф навсегда. Карта не нужна.',
+    subtitle: 'Бесплатный тариф навсегда: 3 соцсети и 10 постов в месяц. Карта не нужна.',
   },
   reset: {
     title: 'Восстановим пароль',
@@ -41,16 +41,19 @@ export function AuthModal() {
       title={null}
     >
       <Stack gap="xs">
-        <SegmentedControl
-          fullWidth
-          color="dark"
-          value={mode === 'register' ? 'register' : 'login'}
-          onChange={(v) => setMode(v as AuthMode)}
-          data={[
-            { label: 'Вход', value: 'login' },
-            { label: 'Регистрация', value: 'register' },
-          ]}
-        />
+        {/* Вкладки — только в режимах входа/регистрации: в режиме сброса их нет (как в макете) */}
+        {isAuth && (
+          <SegmentedControl
+            fullWidth
+            color="dark"
+            value={mode === 'register' ? 'register' : 'login'}
+            onChange={(v) => setMode(v as AuthMode)}
+            data={[
+              { label: 'Вход', value: 'login' },
+              { label: 'Регистрация', value: 'register' },
+            ]}
+          />
+        )}
 
         <div>
           <Title order={3} fz={18} fw={800}>

--- a/frontend/src/features/auth/ui/LoginForm.tsx
+++ b/frontend/src/features/auth/ui/LoginForm.tsx
@@ -1,8 +1,20 @@
-import { Anchor, Button, Checkbox, Group, PasswordInput, Stack, TextInput } from '@mantine/core'
+import { useState } from 'react'
+import {
+  Alert,
+  Anchor,
+  Button,
+  Checkbox,
+  Group,
+  PasswordInput,
+  Stack,
+  TextInput,
+} from '@mantine/core'
+import { IconAlertCircle } from '@tabler/icons-react'
 import { useForm } from '@mantine/form'
 import { useDispatch } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
 import { login } from '@/entities/session'
+import { getAuthErrorMessage, mockLogin } from '../api/mockAuthApi'
 import { useAuthModal } from '../model/hooks'
 
 interface LoginValues {
@@ -16,6 +28,10 @@ export function LoginForm() {
   const dispatch = useDispatch()
   const navigate = useNavigate()
 
+  // Состояния мок-запроса: спиннер в кнопке + блокировка полей, ошибка — в Alert
+  const [pending, setPending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
   const form = useForm<LoginValues>({
     initialValues: { email: '', password: '', remember: false },
     validate: {
@@ -24,11 +40,24 @@ export function LoginForm() {
     },
   })
 
-  const submit = form.onSubmit(() => {
-    // TODO (Design First): POST /auth/login (email + password, remember-me), issue #110. Пока мок.
-    dispatch(login())
-    close()
-    navigate('/app/calendar')
+  const submit = form.onSubmit(async (values) => {
+    setError(null)
+    setPending(true)
+    try {
+      // Мок вместо POST /auth/login (#110): «Запомнить меня» уже прокидывается как rememberMe
+      await mockLogin({
+        email: values.email,
+        password: values.password,
+        rememberMe: values.remember,
+      })
+      dispatch(login())
+      close()
+      navigate('/app/calendar')
+    } catch (e) {
+      setError(getAuthErrorMessage(e))
+    } finally {
+      setPending(false)
+    }
   })
 
   return (
@@ -38,26 +67,34 @@ export function LoginForm() {
           label="Почта"
           placeholder="you@example.ru"
           withAsterisk
+          disabled={pending}
           {...form.getInputProps('email')}
         />
         <PasswordInput
           label="Пароль"
           placeholder="••••••••"
           withAsterisk
+          disabled={pending}
           {...form.getInputProps('password')}
         />
         <Group justify="space-between">
           <Checkbox
             label="Запомнить меня"
+            disabled={pending}
             {...form.getInputProps('remember', { type: 'checkbox' })}
           />
           <Anchor component="button" type="button" size="sm" onClick={() => setMode('reset')}>
             Забыли пароль?
           </Anchor>
         </Group>
-        <Button type="submit" fullWidth mt={2}>
+        <Button type="submit" fullWidth mt={2} loading={pending}>
           Войти
         </Button>
+        {error && (
+          <Alert color="red" icon={<IconAlertCircle size={18} />}>
+            {error}
+          </Alert>
+        )}
       </Stack>
     </form>
   )

--- a/frontend/src/features/auth/ui/RegisterForm.tsx
+++ b/frontend/src/features/auth/ui/RegisterForm.tsx
@@ -1,8 +1,11 @@
-import { Anchor, Button, Checkbox, PasswordInput, Stack, TextInput } from '@mantine/core'
+import { useState } from 'react'
+import { Alert, Anchor, Button, Checkbox, PasswordInput, Stack, TextInput } from '@mantine/core'
+import { IconAlertCircle } from '@tabler/icons-react'
 import { useForm } from '@mantine/form'
 import { useDispatch } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
 import { login } from '@/entities/session'
+import { getAuthErrorMessage, mockRegister } from '../api/mockAuthApi'
 import { useAuthModal } from '../model/hooks'
 
 interface RegisterValues {
@@ -17,6 +20,10 @@ export function RegisterForm() {
   const dispatch = useDispatch()
   const navigate = useNavigate()
 
+  // Состояния мок-запроса: спиннер в кнопке + блокировка полей, ошибка — в Alert
+  const [pending, setPending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
   const form = useForm<RegisterValues>({
     initialValues: { name: '', email: '', password: '', oferta: false },
     validate: {
@@ -27,11 +34,20 @@ export function RegisterForm() {
     },
   })
 
-  const submit = form.onSubmit(() => {
-    // TODO (Design First): POST /auth/register + провижининг free-тарифа, issue #110. Пока мок.
-    dispatch(login())
-    close()
-    navigate('/app/calendar')
+  const submit = form.onSubmit(async (values) => {
+    setError(null)
+    setPending(true)
+    try {
+      // Мок вместо POST /auth/register + провижининг free-тарифа (#110)
+      await mockRegister({ name: values.name, email: values.email, password: values.password })
+      dispatch(login())
+      close()
+      navigate('/app/calendar')
+    } catch (e) {
+      setError(getAuthErrorMessage(e))
+    } finally {
+      setPending(false)
+    }
   })
 
   return (
@@ -41,38 +57,48 @@ export function RegisterForm() {
           label="Как вас зовут"
           placeholder="Мария"
           withAsterisk
+          disabled={pending}
           {...form.getInputProps('name')}
         />
         <TextInput
           label="Почта"
           placeholder="you@example.ru"
           withAsterisk
+          disabled={pending}
           {...form.getInputProps('email')}
         />
         <PasswordInput
           label="Пароль"
           placeholder="••••••••"
           withAsterisk
+          disabled={pending}
           {...form.getInputProps('password')}
         />
         <Checkbox
+          disabled={pending}
           {...form.getInputProps('oferta', { type: 'checkbox' })}
           label={
             <>
               Принимаю{' '}
-              <Anchor href="/legal" target="_blank">
+              <Anchor href="/legal#oferta" target="_blank">
                 оферту
               </Anchor>{' '}
               и{' '}
-              <Anchor href="/legal" target="_blank">
+              <Anchor href="/legal#privacy" target="_blank">
                 политику конфиденциальности
               </Anchor>
             </>
           }
         />
-        <Button type="submit" fullWidth mt={2}>
+        {/* Кнопка неактивна, пока не отмечен чекбокс согласия с офертой */}
+        <Button type="submit" fullWidth mt={2} disabled={!form.values.oferta} loading={pending}>
           Создать аккаунт
         </Button>
+        {error && (
+          <Alert color="red" icon={<IconAlertCircle size={18} />}>
+            {error}
+          </Alert>
+        )}
       </Stack>
     </form>
   )

--- a/frontend/src/features/auth/ui/ResetForm.tsx
+++ b/frontend/src/features/auth/ui/ResetForm.tsx
@@ -1,7 +1,8 @@
-import { Alert, Button, Stack, TextInput } from '@mantine/core'
-import { IconMailCheck } from '@tabler/icons-react'
-import { useForm } from '@mantine/form'
 import { useState } from 'react'
+import { Alert, Button, Stack, TextInput } from '@mantine/core'
+import { IconAlertCircle, IconMailCheck } from '@tabler/icons-react'
+import { useForm } from '@mantine/form'
+import { getAuthErrorMessage, mockRequestPasswordReset } from '../api/mockAuthApi'
 
 interface ResetValues {
   email: string
@@ -10,6 +11,10 @@ interface ResetValues {
 export function ResetForm() {
   const [sent, setSent] = useState(false)
 
+  // Состояния мок-запроса: спиннер в кнопке + блокировка поля, ошибка — в Alert
+  const [pending, setPending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
   const form = useForm<ResetValues>({
     initialValues: { email: '' },
     validate: {
@@ -17,16 +22,25 @@ export function ResetForm() {
     },
   })
 
-  const submit = form.onSubmit(() => {
-    // TODO (Design First): POST /auth/password-reset (email), issue #110. Пока заглушка.
-    setSent(true)
+  const submit = form.onSubmit(async (values) => {
+    setError(null)
+    setPending(true)
+    try {
+      // Мок вместо POST /auth/password-reset (#110)
+      await mockRequestPasswordReset(values.email)
+      setSent(true)
+    } catch (e) {
+      setError(getAuthErrorMessage(e))
+    } finally {
+      setPending(false)
+    }
   })
 
   if (sent) {
     return (
       <Stack gap="sm">
         <Alert color="green" icon={<IconMailCheck size={18} />} title="Ссылка отправлена.">
-          Проверьте почту — там ссылка для сброса пароля.
+          Проверьте входящие — а если письма нет, загляните в «Спам».
         </Alert>
         <Button variant="light" fullWidth onClick={() => setSent(false)}>
           Отправить ещё раз
@@ -42,11 +56,17 @@ export function ResetForm() {
           label="Почта"
           placeholder="you@example.ru"
           withAsterisk
+          disabled={pending}
           {...form.getInputProps('email')}
         />
-        <Button type="submit" fullWidth mt={4}>
+        <Button type="submit" fullWidth mt={4} loading={pending}>
           Отправить ссылку
         </Button>
+        {error && (
+          <Alert color="red" icon={<IconAlertCircle size={18} />}>
+            {error}
+          </Alert>
+        )}
       </Stack>
     </form>
   )


### PR DESCRIPTION
Closes #187

Стек: после PR #181-landing-polish. **Модальная трактовка по решению заказчика** — детали в комментарии к issue #187.

- Гейт вкладок: SegmentedControl «Вход/Регистрация» скрыт в режиме сброса пароля
- Мок-API (features/auth/api/mockAuthApi.ts, задержка ~600мс): mockLogin/mockRegister/mockRequestPasswordReset; триггеры ошибок для ручной проверки — пароль `wrong` (вход), `taken@example.ru` (регистрация), `unknown@example.ru` (сброс)
- Все 3 формы: Button loading + disabled-поля на время запроса, ошибка — красный Alert, сбрасывается при повторной отправке
- «Создать аккаунт» disabled до отметки оферты; ссылки чекбокса → /legal#oferta и /legal#privacy
- Тексты по макету login.html: подзаголовок регистрации, текст успешного сброса
- «Запомнить меня» прокидывается как rememberMe (контракт готов к реальному POST /auth/login #110)

Проверено: lint/tsc/build чисто; живой прогон — loading-состояние, ошибка «Неверная почта или пароль», скрытие вкладок в сбросе, успешный вход в кабинет.