### PR TITLE
feat(frontend): модалки загрузки медиа — Dropzone, мульти-загрузка, выбор из медиатеки

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@fontsource-variable/golos-text": "^5.2.8",
         "@mantine/core": "^7.15.0",
         "@mantine/dates": "^7.15.0",
+        "@mantine/dropzone": "^7.17.8",
         "@mantine/form": "^7.15.0",
         "@mantine/hooks": "^7.15.0",
         "@mantine/notifications": "^7.15.0",
@@ -1325,6 +1326,21 @@
         "@mantine/core": "7.17.8",
         "@mantine/hooks": "7.17.8",
         "dayjs": ">=1.0.0",
+        "react": "^18.x || ^19.x",
+        "react-dom": "^18.x || ^19.x"
+      }
+    },
+    "node_modules/@mantine/dropzone": {
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@mantine/dropzone/-/dropzone-7.17.8.tgz",
+      "integrity": "sha512-c9WEArpP23E9tbRWqoznEY3bGPVntMuBKr3F2LQijgdpdALIzt6DYmwXu7gUajGX9Qg9NrCHenhvWLTYqKnRlA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-dropzone-esm": "15.2.0"
+      },
+      "peerDependencies": {
+        "@mantine/core": "7.17.8",
+        "@mantine/hooks": "7.17.8",
         "react": "^18.x || ^19.x",
         "react-dom": "^18.x || ^19.x"
       }
@@ -4249,6 +4265,21 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-dropzone-esm": {
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/react-dropzone-esm/-/react-dropzone-esm-15.2.0.tgz",
+      "integrity": "sha512-pPwR8xWVL+tFLnbAb8KVH5f6Vtl397tck8dINkZ1cPMxHWH+l9dFmIgRWgbh7V7jbjIcuKXCsVrXbhQz68+dVA==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8 || 18.0.0"
       }
     },
     "node_modules/react-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@fontsource-variable/golos-text": "^5.2.8",
     "@mantine/core": "^7.15.0",
     "@mantine/dates": "^7.15.0",
+    "@mantine/dropzone": "^7.17.8",
     "@mantine/form": "^7.15.0",
     "@mantine/hooks": "^7.15.0",
     "@mantine/notifications": "^7.15.0",

--- a/frontend/src/entities/media/api/mediaApi.ts
+++ b/frontend/src/entities/media/api/mediaApi.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { getMediaStore, removeFromMediaStore } from '../model/mock'
+import { mediaFromFile } from '../lib/upload'
+import { addToMediaStore, getMediaStore, removeFromMediaStore } from '../model/mock'
 import type { Media } from '../model/types'
 
 export const mediaKeys = {
@@ -20,6 +21,28 @@ export function useMedia() {
       return getMediaStore()
     },
     staleTime: Infinity,
+  })
+}
+
+/**
+ * «Загрузка» файла на мок-уровне: валидация типа/размера — на стороне дроп-зоны,
+ * здесь файл превращается в элемент медиатеки, попадает в in-memory список
+ * и сразу в кэш по mediaKeys.all (setQueryData). Возвращает созданный элемент —
+ * вызывающему может понадобиться его id (например, чтобы прикрепить к посту).
+ * TODO (Design First, backlog #147): заменить mutationFn на POST /media (multipart).
+ */
+export function useUploadMediaMutation() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (file: File): Promise<{ item: Media; list: Media[] }> => {
+      // Эмуляция сетевой задержки, пока нет реального API.
+      await new Promise((resolve) => setTimeout(resolve, 900))
+      const item = mediaFromFile(file)
+      return { item, list: addToMediaStore(item) }
+    },
+    onSuccess: ({ list }) => {
+      queryClient.setQueryData(mediaKeys.all, list)
+    },
   })
 }
 

--- a/frontend/src/entities/media/index.ts
+++ b/frontend/src/entities/media/index.ts
@@ -1,9 +1,21 @@
-export { useMedia, mediaKeys, useDeleteMediaMutation } from './api/mediaApi'
+export { useMedia, mediaKeys, useDeleteMediaMutation, useUploadMediaMutation } from './api/mediaApi'
 export { MEDIA_MOCK } from './model/mock'
+export {
+  MEDIA_MAX_VIDEO_SIZE,
+  MEDIA_MAX_PHOTO_SIZE,
+  MEDIA_LIBRARY_ACCEPT,
+  MEDIA_PHOTO_ACCEPT,
+  MEDIA_VIDEO_ACCEPT,
+  MEDIA_LIBRARY_FORMATS_LABEL,
+  MEDIA_PHOTO_FORMATS_LABEL,
+  MEDIA_VIDEO_FORMATS_LABEL,
+} from './model/uploadConfig'
 export { MediaTile } from './ui/MediaTile'
 export { MediaThumb } from './ui/MediaThumb'
 export { PlayOverlay } from './ui/PlayOverlay'
+export { UploadDropzone } from './ui/UploadDropzone'
 export { formatDateShort } from './lib/date'
 export { getMediaTypeLabel } from './lib/format'
+export { pluralizeRu, FILE_PLURAL_FORMS } from './lib/plural'
 export { MEDIA_PREVIEW_FALLBACK } from './lib/preview'
 export type { Media } from './model/types'

--- a/frontend/src/entities/media/lib/plural.ts
+++ b/frontend/src/entities/media/lib/plural.ts
@@ -1,0 +1,17 @@
+/**
+ * Плюрализация по-русски: выбирает форму слова по числу.
+ * Формы: [одна штука, 2–4 штуки, много] — например ['файл', 'файла', 'файлов'].
+ * 1 → «файл», 2 → «файла», 5 → «файлов», 11 → «файлов», 21 → «файл».
+ */
+export function pluralizeRu(count: number, forms: [string, string, string]): string {
+  const abs = Math.abs(Math.trunc(count))
+  const mod100 = abs % 100
+  const mod10 = abs % 10
+  if (mod100 >= 11 && mod100 <= 14) return forms[2]
+  if (mod10 === 1) return forms[0]
+  if (mod10 >= 2 && mod10 <= 4) return forms[1]
+  return forms[2]
+}
+
+/** Формы слова «файл» для счётчиков загрузки: 1 файл, 2 файла, 5 файлов. */
+export const FILE_PLURAL_FORMS: [string, string, string] = ['файл', 'файла', 'файлов']

--- a/frontend/src/entities/media/lib/preview.ts
+++ b/frontend/src/entities/media/lib/preview.ts
@@ -17,3 +17,7 @@ export function makeMockPreviewUrl(
 
 /** Fallback предпросмотра на случай пустого или битого url (Image fallbackSrc). */
 export const MEDIA_PREVIEW_FALLBACK = makeMockPreviewUrl('превью недоступно')
+
+/** Тёмный кадр для видео-заглушек (превью «стоп-кадра») — и в моках, и у загруженных. */
+export const VIDEO_PREVIEW_BG = '#26241D'
+export const VIDEO_PREVIEW_FG = 'rgba(255,255,255,.75)'

--- a/frontend/src/entities/media/lib/upload.ts
+++ b/frontend/src/entities/media/lib/upload.ts
@@ -1,0 +1,41 @@
+import { makeMockPreviewUrl, VIDEO_PREVIEW_BG, VIDEO_PREVIEW_FG } from './preview'
+import type { Media } from '../model/types'
+
+const SIZE_UNITS = ['Б', 'КБ', 'МБ', 'ГБ'] as const
+
+/** Человекочитаемый размер файла в стиле моков: «640 КБ», «1,8 МБ», «128 МБ». */
+export function formatFileSize(bytes: number): string {
+  let value = bytes
+  let unit = 0
+  while (value >= 1024 && unit < SIZE_UNITS.length - 1) {
+    value /= 1024
+    unit += 1
+  }
+  // До 10 показываем один знак после запятой («1,8 МБ»), дальше — целое («128 МБ»).
+  const rounded = unit === 0 || value >= 10 ? Math.round(value) : Math.round(value * 10) / 10
+  return `${String(rounded).replace('.', ',')} ${SIZE_UNITS[unit]}`
+}
+
+// Сквозной счётчик для уникальных id: Date.now() может совпасть у файлов одного дропа.
+let uploadCounter = 0
+
+/**
+ * Собирает элемент медиатеки из выбранного пользователем файла (мок-уровень).
+ * Для фото превью настоящее — через URL.createObjectURL, для видео —
+ * SVG-заглушка «стоп-кадра», как у видео-моков.
+ */
+export function mediaFromFile(file: File): Media {
+  const kind: Media['kind'] = file.type.startsWith('video/') ? 'video' : 'photo'
+  uploadCounter += 1
+  return {
+    id: `upload-${Date.now()}-${uploadCounter}`,
+    name: file.name,
+    kind,
+    sizeLabel: formatFileSize(file.size),
+    url:
+      kind === 'photo'
+        ? URL.createObjectURL(file)
+        : makeMockPreviewUrl(file.name, VIDEO_PREVIEW_BG, VIDEO_PREVIEW_FG),
+    uploadedAt: new Date().toISOString(),
+  }
+}

--- a/frontend/src/entities/media/model/mock.ts
+++ b/frontend/src/entities/media/model/mock.ts
@@ -1,9 +1,5 @@
-import { makeMockPreviewUrl } from '../lib/preview'
+import { makeMockPreviewUrl, VIDEO_PREVIEW_BG, VIDEO_PREVIEW_FG } from '../lib/preview'
 import type { Media } from './types'
-
-// Тёмный кадр для видео-заглушек (превью «стоп-кадра»).
-const VIDEO_BG = '#26241D'
-const VIDEO_FG = 'rgba(255,255,255,.75)'
 
 /**
  * Мок медиатеки (~8 элементов, микс фото/видео). url — data-URI-заглушки,
@@ -26,7 +22,7 @@ export const MEDIA_MOCK: Media[] = [
     name: 'Ролик-бэкстейдж.mp4',
     kind: 'video',
     sizeLabel: '128 МБ',
-    url: makeMockPreviewUrl('Ролик-бэкстейдж.mp4', VIDEO_BG, VIDEO_FG),
+    url: makeMockPreviewUrl('Ролик-бэкстейдж.mp4', VIDEO_PREVIEW_BG, VIDEO_PREVIEW_FG),
     uploadedAt: '2026-06-28T14:40:00',
   },
   {
@@ -42,7 +38,7 @@ export const MEDIA_MOCK: Media[] = [
     name: 'Промо-шортс.mp4',
     kind: 'video',
     sizeLabel: '54 МБ',
-    url: makeMockPreviewUrl('Промо-шортс.mp4', VIDEO_BG, VIDEO_FG),
+    url: makeMockPreviewUrl('Промо-шортс.mp4', VIDEO_PREVIEW_BG, VIDEO_PREVIEW_FG),
     uploadedAt: '2026-06-25T18:30:00',
   },
   {
@@ -65,7 +61,7 @@ export const MEDIA_MOCK: Media[] = [
     name: 'Анонс-вебинара.mp4',
     kind: 'video',
     sizeLabel: '96 МБ',
-    url: makeMockPreviewUrl('Анонс-вебинара.mp4', VIDEO_BG, VIDEO_FG),
+    url: makeMockPreviewUrl('Анонс-вебинара.mp4', VIDEO_PREVIEW_BG, VIDEO_PREVIEW_FG),
     uploadedAt: '2026-06-20T10:45:00',
   },
   {

--- a/frontend/src/entities/media/model/uploadConfig.ts
+++ b/frontend/src/entities/media/model/uploadConfig.ts
@@ -1,0 +1,26 @@
+import { MIME_TYPES } from '@mantine/dropzone'
+
+// Лимиты и форматы загрузки медиа из макета app-dashboard.html
+// (блоки «ЗАГРУЗКА В МЕДИАТЕКУ» и «ЗАГРУЗКА ФАЙЛА»). Используются и модалкой
+// медиатеки, и модалкой прикрепления файла к посту — строки не дублируем.
+// TODO (Design First, backlog): забирать лимиты из OpenAPI-схемы, когда появится бэкенд.
+
+/** Максимальный размер видео и файлов «Загрузки в медиатеку»: 2 ГБ. */
+export const MEDIA_MAX_VIDEO_SIZE = 2 * 1024 ** 3
+
+/** Максимальный размер фото и обложек: 20 МБ. */
+export const MEDIA_MAX_PHOTO_SIZE = 20 * 1024 ** 2
+
+/** MIME-типы «Загрузки в медиатеку»: фото и видео вперемешку. */
+export const MEDIA_LIBRARY_ACCEPT: string[] = [MIME_TYPES.jpeg, MIME_TYPES.png, MIME_TYPES.mp4]
+
+/** MIME-типы загрузки фото и обложки. */
+export const MEDIA_PHOTO_ACCEPT: string[] = [MIME_TYPES.jpeg, MIME_TYPES.png]
+
+/** MIME-типы загрузки видео (MOV = video/quicktime, в MIME_TYPES его нет). */
+export const MEDIA_VIDEO_ACCEPT: string[] = [MIME_TYPES.mp4, 'video/quicktime']
+
+/** Подписи форматов под дроп-зонами — ровно как в макете. */
+export const MEDIA_LIBRARY_FORMATS_LABEL = 'JPG, PNG, MP4 до 2 ГБ'
+export const MEDIA_PHOTO_FORMATS_LABEL = 'JPG, PNG до 20 МБ'
+export const MEDIA_VIDEO_FORMATS_LABEL = 'MP4, MOV до 2 ГБ'

--- a/frontend/src/entities/media/ui/UploadDropzone.module.css
+++ b/frontend/src/entities/media/ui/UploadDropzone.module.css
@@ -1,0 +1,21 @@
+/* Дроп-зона по макету app-dashboard.html: синяя пунктирная рамка, лёгкая подложка бренда. */
+.root {
+  border: 1.5px dashed rgba(43, 80, 236, 0.45);
+  border-radius: 12px;
+  background: rgba(43, 80, 236, 0.04);
+  padding: 30px 16px;
+  transition:
+    background 120ms ease,
+    border-color 120ms ease;
+}
+
+.root:hover,
+.root[data-accept] {
+  background: rgba(43, 80, 236, 0.08);
+}
+
+/* Файл не проходит по типу/размеру — зона подсвечивается красным ещё до дропа. */
+.root[data-reject] {
+  border-color: var(--mantine-color-red-5);
+  background: var(--mantine-color-red-0);
+}

--- a/frontend/src/entities/media/ui/UploadDropzone.tsx
+++ b/frontend/src/entities/media/ui/UploadDropzone.tsx
@@ -1,0 +1,60 @@
+// Стили пакета подключаем здесь же: все точки входа дроп-зон проходят через этот компонент.
+import '@mantine/dropzone/styles.css'
+import { Text } from '@mantine/core'
+import { Dropzone } from '@mantine/dropzone'
+import type { FileRejection } from '@mantine/dropzone'
+import classes from './UploadDropzone.module.css'
+
+interface UploadDropzoneProps {
+  /** MIME-типы, которые зона принимает (константы в model/uploadConfig). */
+  accept: string[]
+  /** Максимальный размер файла в байтах (константы в model/uploadConfig). */
+  maxSize: number
+  /** Разрешён ли выбор нескольких файлов сразу. */
+  multiple?: boolean
+  /** Заголовок зоны: «Перетащите файлы сюда» / «Перетащите файл сюда». */
+  title: string
+  /** Подпись под заголовком: «или нажмите, чтобы выбрать · …». */
+  hint: string
+  /** Оверлей с лоадером на время мок-загрузки (блокирует повторный дроп). */
+  loading?: boolean
+  /** Файлы, прошедшие валидацию типа и размера. */
+  onDrop: (files: File[]) => void
+  /** Файлы, отклонённые клиентской валидацией accept/maxSize. */
+  onReject?: (rejections: FileRejection[]) => void
+}
+
+/**
+ * Общая дроп-зона загрузки медиа: drag-and-drop, клик-выбор и валидация
+ * accept/maxSize из коробки (@mantine/dropzone). Используется модалками
+ * «Загрузка в медиатеку» и «Загрузка файла».
+ */
+export function UploadDropzone({
+  accept,
+  maxSize,
+  multiple = false,
+  title,
+  hint,
+  loading,
+  onDrop,
+  onReject,
+}: UploadDropzoneProps) {
+  return (
+    <Dropzone
+      accept={accept}
+      maxSize={maxSize}
+      multiple={multiple}
+      loading={loading}
+      onDrop={onDrop}
+      onReject={onReject}
+      classNames={{ root: classes.root }}
+    >
+      <Text fz={13.5} fw={700} c="brand" ta="center">
+        {title}
+      </Text>
+      <Text mt={4} fz={12} c="dimmed" ta="center">
+        {hint}
+      </Text>
+    </Dropzone>
+  )
+}

--- a/frontend/src/features/attach-media/index.ts
+++ b/frontend/src/features/attach-media/index.ts
@@ -1,0 +1,2 @@
+export { AttachMediaModal } from './ui/AttachMediaModal'
+export type { AttachmentKind } from './model/config'

--- a/frontend/src/features/attach-media/model/config.ts
+++ b/frontend/src/features/attach-media/model/config.ts
@@ -1,0 +1,49 @@
+import {
+  MEDIA_MAX_PHOTO_SIZE,
+  MEDIA_MAX_VIDEO_SIZE,
+  MEDIA_PHOTO_ACCEPT,
+  MEDIA_VIDEO_ACCEPT,
+  MEDIA_PHOTO_FORMATS_LABEL,
+  MEDIA_VIDEO_FORMATS_LABEL,
+} from '@/entities/media'
+
+/** Тип вложения поста — его передаёт вызывающий (композер). */
+export type AttachmentKind = 'photo' | 'video' | 'cover'
+
+interface AttachmentKindConfig {
+  /** Заголовок модалки. */
+  title: string
+  /** Подпись форматов под дроп-зоной. */
+  formatsLabel: string
+  /** MIME-типы для клиентской валидации. */
+  accept: string[]
+  /** Лимит размера файла в байтах. */
+  maxSize: number
+  /** Показывать ли блок «Или выберите из медиатеки» (только фото и обложка). */
+  withLibrary: boolean
+}
+
+/** Настройки модалки «Загрузка файла» по типу вложения — тексты из макета. */
+export const ATTACHMENT_KIND_CONFIG: Record<AttachmentKind, AttachmentKindConfig> = {
+  photo: {
+    title: 'Загрузить фото',
+    formatsLabel: MEDIA_PHOTO_FORMATS_LABEL,
+    accept: MEDIA_PHOTO_ACCEPT,
+    maxSize: MEDIA_MAX_PHOTO_SIZE,
+    withLibrary: true,
+  },
+  video: {
+    title: 'Загрузить видео',
+    formatsLabel: MEDIA_VIDEO_FORMATS_LABEL,
+    accept: MEDIA_VIDEO_ACCEPT,
+    maxSize: MEDIA_MAX_VIDEO_SIZE,
+    withLibrary: false,
+  },
+  cover: {
+    title: 'Загрузить обложку',
+    formatsLabel: MEDIA_PHOTO_FORMATS_LABEL,
+    accept: MEDIA_PHOTO_ACCEPT,
+    maxSize: MEDIA_MAX_PHOTO_SIZE,
+    withLibrary: true,
+  },
+}

--- a/frontend/src/features/attach-media/ui/AttachMediaModal.module.css
+++ b/frontend/src/features/attach-media/ui/AttachMediaModal.module.css
@@ -1,0 +1,20 @@
+/* Плитка быстрого выбора из медиатеки — пунктирная, как в макете app-dashboard.html. */
+.libraryTile {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  aspect-ratio: 4 / 3;
+  border: 1.5px dashed rgba(23, 21, 15, 0.2);
+  border-radius: 9px;
+  background: #f6f4ef;
+  color: rgba(23, 21, 15, 0.5);
+  text-align: center;
+  transition:
+    border-color 120ms ease,
+    color 120ms ease;
+}
+
+.libraryTile:hover {
+  border-color: var(--mantine-color-brand-6);
+  color: var(--mantine-color-brand-6);
+}

--- a/frontend/src/features/attach-media/ui/AttachMediaModal.tsx
+++ b/frontend/src/features/attach-media/ui/AttachMediaModal.tsx
@@ -1,0 +1,101 @@
+import { Modal, SimpleGrid, Text, UnstyledButton } from '@mantine/core'
+import { notifications } from '@mantine/notifications'
+import type { FileRejection } from '@mantine/dropzone'
+import { UploadDropzone, useMedia, useUploadMediaMutation } from '@/entities/media'
+import { ATTACHMENT_KIND_CONFIG } from '../model/config'
+import type { AttachmentKind } from '../model/config'
+import classes from './AttachMediaModal.module.css'
+
+interface AttachMediaModalProps {
+  opened: boolean
+  /** Тип вложения от вызывающего (композера): фото / видео / обложка. */
+  kind: AttachmentKind
+  onClose: () => void
+  /**
+   * Итог выбора — id медиа: существующего из медиатеки или только что
+   * загруженного. Модалка про пост ничего не знает, прикрепление — на вызывающем.
+   */
+  onSelect: (mediaId: string) => void
+}
+
+/**
+ * Модалка «Загрузка файла»: дроп-зона с валидацией по типу вложения и,
+ * для фото/обложки, быстрый выбор из первых четырёх фото медиатеки.
+ * Загруженный через зону файл тоже попадает в медиатеку (мок-уровень),
+ * а наружу в обоих случаях уходит mediaId через onSelect.
+ */
+export function AttachMediaModal({ opened, kind, onClose, onSelect }: AttachMediaModalProps) {
+  const config = ATTACHMENT_KIND_CONFIG[kind]
+  const upload = useUploadMediaMutation()
+  const { data } = useMedia()
+  // Первые 4 фото медиатеки — плитки быстрого выбора, как в макете.
+  const libraryPhotos = (data ?? []).filter((item) => item.kind === 'photo').slice(0, 4)
+
+  const pick = (mediaId: string) => {
+    onSelect(mediaId)
+    onClose()
+  }
+
+  // Файл сперва «загружается» в медиатеку, затем его id уходит вызывающему.
+  // mutateAsync вместо mutate: колбэки mutate() при повторных вызовах одного
+  // useMutation перекрывают друг друга (см. MediaUploadModal).
+  const handleDrop = (files: File[]) => {
+    const file = files[0]
+    if (!file) return
+    void upload.mutateAsync(file).then(({ item }) => pick(item.id))
+  }
+
+  // Клиентская валидация не прошла (тип или размер) — объясняем, что подходит.
+  const handleReject = (rejections: FileRejection[]) => {
+    const names = rejections.map((rejection) => rejection.file.name).join(', ')
+    notifications.show({
+      color: 'red',
+      message: `Файл не подходит: ${names}. Допустимы ${config.formatsLabel}.`,
+    })
+  }
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      title={config.title}
+      radius="lg"
+      centered
+      size={460}
+      styles={{ title: { fontWeight: 800, fontSize: 17, letterSpacing: '-.2px' } }}
+    >
+      <UploadDropzone
+        accept={config.accept}
+        maxSize={config.maxSize}
+        title="Перетащите файл сюда"
+        hint={`или нажмите, чтобы выбрать с компьютера · ${config.formatsLabel}`}
+        loading={upload.isPending}
+        onDrop={handleDrop}
+        onReject={handleReject}
+      />
+
+      {/* Для фото и обложки — быстрый выбор из существующих фото медиатеки */}
+      {config.withLibrary && libraryPhotos.length > 0 ? (
+        <>
+          <Text mt={14} fz={12.5} fw={600} style={{ color: 'rgba(23,21,15,.6)' }}>
+            Или выберите из медиатеки
+          </Text>
+          <SimpleGrid cols={4} spacing={8} mt={8}>
+            {libraryPhotos.map((photo) => (
+              <UnstyledButton
+                key={photo.id}
+                className={classes.libraryTile}
+                title={photo.name}
+                onClick={() => pick(photo.id)}
+              >
+                <Text component="span" fz={10.5} c="inherit" lineClamp={2} px={4}>
+                  {photo.name}
+                </Text>
+              </UnstyledButton>
+            ))}
+          </SimpleGrid>
+        </>
+      ) : null}
+    </Modal>
+  )
+}

--- a/frontend/src/features/media-upload/index.ts
+++ b/frontend/src/features/media-upload/index.ts
@@ -1,0 +1,1 @@
+export { MediaUploadModal } from './ui/MediaUploadModal'

--- a/frontend/src/features/media-upload/ui/MediaUploadModal.tsx
+++ b/frontend/src/features/media-upload/ui/MediaUploadModal.tsx
@@ -1,0 +1,130 @@
+import { useState } from 'react'
+import { Button, Group, Loader, Modal, Stack, Text } from '@mantine/core'
+import { notifications } from '@mantine/notifications'
+import { IconCheck } from '@tabler/icons-react'
+import { useQueryClient } from '@tanstack/react-query'
+import type { FileRejection } from '@mantine/dropzone'
+import {
+  UploadDropzone,
+  useUploadMediaMutation,
+  mediaKeys,
+  pluralizeRu,
+  FILE_PLURAL_FORMS,
+  MEDIA_LIBRARY_ACCEPT,
+  MEDIA_LIBRARY_FORMATS_LABEL,
+  MEDIA_MAX_VIDEO_SIZE,
+} from '@/entities/media'
+
+/** Строка пофайлового статуса текущего сеанса загрузки. */
+interface UploadRow {
+  key: string
+  name: string
+  status: 'uploading' | 'done'
+}
+
+// Сквозной счётчик ключей строк: имена файлов могут повторяться в одном дропе.
+let rowCounter = 0
+
+interface MediaUploadModalProps {
+  opened: boolean
+  onClose: () => void
+}
+
+/**
+ * Модалка «Загрузка в медиатеку»: мульти-выбор через дроп-зону, пофайловый
+ * мок-прогресс и счётчик «Загружено в этой сессии». Кнопка «Готово» закрывает
+ * модалку и инвалидирует запрос медиатеки — сетка обновляется.
+ */
+export function MediaUploadModal({ opened, onClose }: MediaUploadModalProps) {
+  const [rows, setRows] = useState<UploadRow[]>([])
+  const upload = useUploadMediaMutation()
+  const queryClient = useQueryClient()
+
+  // Каждый файл «грузится» отдельно: свой лоадер, своя отметка «готово».
+  const handleDrop = (files: File[]) => {
+    files.forEach((file) => {
+      rowCounter += 1
+      const key = `upload-row-${rowCounter}`
+      setRows((prev) => [...prev, { key, name: file.name, status: 'uploading' }])
+      // Именно mutateAsync: колбэки mutate() при параллельных вызовах одного
+      // useMutation перекрывают друг друга, и ранние файлы «зависали» бы в загрузке.
+      void upload.mutateAsync(file).then(() => {
+        setRows((prev) => prev.map((row) => (row.key === key ? { ...row, status: 'done' } : row)))
+      })
+    })
+  }
+
+  // Клиентская валидация не прошла (тип или размер) — объясняем, что подходит.
+  const handleReject = (rejections: FileRejection[]) => {
+    const names = rejections.map((rejection) => rejection.file.name).join(', ')
+    notifications.show({
+      color: 'red',
+      message: `Не удалось добавить: ${names}. Подходят только ${MEDIA_LIBRARY_FORMATS_LABEL}.`,
+    })
+  }
+
+  // Тот самый TODO из MediaPage: после загрузки обновляем сетку медиатеки.
+  const handleDone = () => {
+    void queryClient.invalidateQueries({ queryKey: mediaKeys.all })
+    onClose()
+  }
+
+  const doneCount = rows.filter((row) => row.status === 'done').length
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      title="Загрузка в медиатеку"
+      radius="lg"
+      centered
+      size={480}
+      styles={{ title: { fontWeight: 800, fontSize: 17, letterSpacing: '-.2px' } }}
+      // Счётчик «за текущий сеанс»: после закрытия (когда анимация доиграла)
+      // статусы сбрасываем, следующее открытие начинается с нуля.
+      transitionProps={{ onExited: () => setRows([]) }}
+    >
+      <UploadDropzone
+        multiple
+        accept={MEDIA_LIBRARY_ACCEPT}
+        maxSize={MEDIA_MAX_VIDEO_SIZE}
+        title="Перетащите файлы сюда"
+        hint={`или нажмите, чтобы выбрать · ${MEDIA_LIBRARY_FORMATS_LABEL}`}
+        onDrop={handleDrop}
+        onReject={handleReject}
+      />
+
+      {/* Пофайловые статусы текущего сеанса: лоадер на время «загрузки», затем галочка */}
+      {rows.length > 0 ? (
+        <Stack gap={6} mt={12}>
+          {rows.map((row) => (
+            <Group key={row.key} gap={8} wrap="nowrap">
+              {row.status === 'uploading' ? (
+                <Loader size={14} />
+              ) : (
+                <IconCheck size={15} stroke={2.6} color="var(--mantine-color-success-6)" />
+              )}
+              <Text fz={12.5} lineClamp={1} style={{ flex: 1 }}>
+                {row.name}
+              </Text>
+              <Text fz={11.5} c="dimmed">
+                {row.status === 'uploading' ? 'загрузка…' : 'готово'}
+              </Text>
+            </Group>
+          ))}
+        </Stack>
+      ) : null}
+
+      {/* Счётчик сеанса с правильным склонением: 1 файл, 2 файла, 5 файлов */}
+      {doneCount > 0 ? (
+        <Text mt={12} fz={12.5} fw={600} c="success.7">
+          ✓ Загружено в этой сессии: {doneCount} {pluralizeRu(doneCount, FILE_PLURAL_FORMS)}
+        </Text>
+      ) : null}
+
+      <Button fullWidth mt="md" color="brand" radius="md" onClick={handleDone}>
+        Готово
+      </Button>
+    </Modal>
+  )
+}

--- a/frontend/src/pages/feature-autoposting/lib/plural.ts
+++ b/frontend/src/pages/feature-autoposting/lib/plural.ts
@@ -1,0 +1,13 @@
+/**
+ * Склонение русских существительных по числу: plural(1|2|5, ['пост', 'поста', 'постов']).
+ * Формула — как в интерактивном макете (docs/design/mockups/feature-autoposting.html).
+ * Кандидат на перенос в shared/lib, как только утилита понадобится другим слайсам.
+ */
+export function plural(n: number, forms: [string, string, string]): string {
+  const a = Math.abs(n) % 100
+  const b = a % 10
+  if (a > 10 && a < 20) return forms[2]
+  if (b > 1 && b < 5) return forms[1]
+  if (b === 1) return forms[0]
+  return forms[2]
+}

--- a/frontend/src/pages/feature-autoposting/ui/AutopostingPage.tsx
+++ b/frontend/src/pages/feature-autoposting/ui/AutopostingPage.tsx
@@ -17,6 +17,7 @@ import type { Icon } from '@tabler/icons-react'
 import { MarketingHeader } from '@/widgets/marketing-header'
 import { MarketingFooter } from '@/widgets/marketing-footer'
 import { useAuthModal } from '@/features/auth'
+import { QueueDemo } from './QueueDemo'
 
 const BORDER = 'rgba(23,21,15,.1)'
 const SOFT_BORDER = 'rgba(23,21,15,.09)'
@@ -45,64 +46,6 @@ const FEATURES: FeatureCard[] = [
   },
 ]
 
-interface QueueItem {
-  short: string
-  color: string
-  label: string
-  when: string
-  status: string
-  statusColor: string
-  statusBg: string
-}
-
-const QUEUE: QueueItem[] = [
-  {
-    short: 'ВК',
-    color: '#0077FF',
-    label: 'Анонс акции',
-    when: 'вт, 09:00',
-    status: 'опубликован',
-    statusColor: '#1E7F4F',
-    statusBg: 'rgba(34,160,107,.12)',
-  },
-  {
-    short: 'TG',
-    color: '#27A6E5',
-    label: 'Утренний дайджест',
-    when: 'вт, 09:05',
-    status: 'опубликован',
-    statusColor: '#1E7F4F',
-    statusBg: 'rgba(34,160,107,.12)',
-  },
-  {
-    short: 'Дз',
-    color: '#1E1E20',
-    label: 'Лонгрид про тренды',
-    when: 'ср, 12:00',
-    status: 'в очереди',
-    statusColor: 'rgba(23,21,15,.55)',
-    statusBg: 'rgba(23,21,15,.07)',
-  },
-  {
-    short: 'ОК',
-    color: '#F7931E',
-    label: 'Опрос для подписчиков',
-    when: 'чт, 19:00',
-    status: 'в очереди',
-    statusColor: 'rgba(23,21,15,.55)',
-    statusBg: 'rgba(23,21,15,.07)',
-  },
-  {
-    short: 'YT',
-    color: '#FF0000',
-    label: 'Шортс: бэкстейдж',
-    when: 'пт, 18:00',
-    status: 'в очереди',
-    statusColor: 'rgba(23,21,15,.55)',
-    statusBg: 'rgba(23,21,15,.07)',
-  },
-]
-
 export function AutopostingPage() {
   const { open } = useAuthModal()
 
@@ -110,9 +53,18 @@ export function AutopostingPage() {
     <Box style={{ background: '#F6F4EF', color: '#17150F' }}>
       <MarketingHeader active="features" />
 
-      {/* Хлебные крошки */}
+      {/* Хлебные крошки: Главная / Возможности / Автопостинг */}
       <Container size="lg" pt={{ base: 20, sm: 28 }}>
         <Text fz={13} c="rgba(23,21,15,.5)">
+          <Text
+            component={Link}
+            to="/"
+            inherit
+            style={{ color: 'inherit', textDecoration: 'none' }}
+          >
+            Главная
+          </Text>{' '}
+          /{' '}
           <Text
             component={Link}
             to="/#features"
@@ -173,7 +125,7 @@ export function AutopostingPage() {
                 </Button>
                 <Button
                   component={Link}
-                  to="/#features"
+                  to="/features/crossposting"
                   size="md"
                   radius="md"
                   variant="outline"
@@ -184,110 +136,8 @@ export function AutopostingPage() {
               </Group>
             </Stack>
 
-            {/* Живое демо: очередь публикаций (статичное представление) */}
-            <Card
-              withBorder
-              radius="lg"
-              p={0}
-              style={{
-                borderColor: BORDER,
-                background: '#fff',
-                boxShadow: '0 12px 32px rgba(23,21,15,.08)',
-                overflow: 'hidden',
-              }}
-            >
-              <Group
-                gap={12}
-                align="center"
-                px={18}
-                py={14}
-                wrap="wrap"
-                style={{ borderBottom: `1px solid ${SOFT_BORDER}` }}
-              >
-                <Text fz={15} fw={700}>
-                  Очередь публикаций
-                </Text>
-                <Badge
-                  radius="xl"
-                  variant="light"
-                  color="brand"
-                  styles={{ root: { textTransform: 'none', fontWeight: 600 } }}
-                >
-                  3 поста в очереди
-                </Badge>
-                <Text ml="auto" fz={12} c="rgba(23,21,15,.48)">
-                  живое демо
-                </Text>
-              </Group>
-
-              <Stack gap={8} px={18} py={14}>
-                {QUEUE.map((item) => (
-                  <Group
-                    key={`${item.short}-${item.label}`}
-                    gap={11}
-                    wrap="nowrap"
-                    align="center"
-                    px={14}
-                    py={10}
-                    style={{
-                      background: '#F6F4EF',
-                      border: `1px solid rgba(23,21,15,.07)`,
-                      borderRadius: 10,
-                    }}
-                  >
-                    <Text
-                      fz={9.5}
-                      fw={700}
-                      c="#fff"
-                      ta="center"
-                      style={{
-                        background: item.color,
-                        borderRadius: 5,
-                        padding: '3px 6px',
-                        minWidth: 22,
-                        flex: 'none',
-                      }}
-                    >
-                      {item.short}
-                    </Text>
-                    <Text fz={14} fw={600}>
-                      {item.label}
-                    </Text>
-                    <Text ml="auto" fz={12.5} c="rgba(23,21,15,.55)" style={{ flex: 'none' }}>
-                      {item.when}
-                    </Text>
-                    <Text
-                      fz={11}
-                      fw={700}
-                      style={{
-                        color: item.statusColor,
-                        background: item.statusBg,
-                        borderRadius: 'var(--mantine-radius-pill)',
-                        padding: '4px 10px',
-                        flex: 'none',
-                        whiteSpace: 'nowrap',
-                      }}
-                    >
-                      {item.status}
-                    </Text>
-                  </Group>
-                ))}
-
-                <Box
-                  px={11}
-                  py={11}
-                  ta="center"
-                  style={{
-                    border: '1.5px dashed rgba(23,21,15,.2)',
-                    borderRadius: 10,
-                  }}
-                >
-                  <Text fz={13.5} fw={600} c="rgba(23,21,15,.5)">
-                    + Добавить в очередь
-                  </Text>
-                </Box>
-              </Stack>
-            </Card>
+            {/* Живое демо: интерактивная очередь публикаций на локальном состоянии */}
+            <QueueDemo />
           </SimpleGrid>
         </Container>
       </Box>

--- a/frontend/src/pages/feature-autoposting/ui/QueueDemo.tsx
+++ b/frontend/src/pages/feature-autoposting/ui/QueueDemo.tsx
@@ -1,0 +1,189 @@
+import { useState } from 'react'
+import { Badge, Card, Group, Stack, Text, UnstyledButton } from '@mantine/core'
+import { NETWORKS } from '@/shared/config'
+import { plural } from '../lib/plural'
+
+const BORDER = 'rgba(23,21,15,.1)'
+const SOFT_BORDER = 'rgba(23,21,15,.09)'
+
+interface QueueItem {
+  /** Уникальный ключ для React (посты из заготовок могут повторяться). */
+  id: string
+  /** Индекс сети в общем справочнике NETWORKS (shared/config). */
+  networkIndex: number
+  label: string
+  when: string
+  /** true — пост уже опубликован, false — ещё ждёт в очереди. */
+  done: boolean
+}
+
+// Стартовая очередь — как в макете feature-autoposting: два поста опубликованы, три ждут.
+const INITIAL_QUEUE: QueueItem[] = [
+  { id: 'seed-1', networkIndex: 0, label: 'Анонс акции', when: 'вт, 09:00', done: true },
+  { id: 'seed-2', networkIndex: 1, label: 'Утренний дайджест', when: 'вт, 09:05', done: true },
+  { id: 'seed-3', networkIndex: 4, label: 'Лонгрид про тренды', when: 'ср, 12:00', done: false },
+  { id: 'seed-4', networkIndex: 2, label: 'Опрос для подписчиков', when: 'чт, 19:00', done: false },
+  { id: 'seed-5', networkIndex: 6, label: 'Шортс: бэкстейдж', when: 'пт, 18:00', done: false },
+]
+
+// Заготовки подписей и времён: новые посты берутся из них по кругу (как LABELS/WHENS в макете).
+const LABELS = [
+  'Анонс акции',
+  'Подборка советов',
+  'Опрос для подписчиков',
+  'Дайджест недели',
+  'Бэкстейдж',
+]
+const WHENS = ['сб, 12:00', 'сб, 15:00', 'вс, 10:00', 'вс, 19:00', 'пн, 09:00']
+
+/**
+ * Интерактивное демо «Очередь публикаций» в hero страницы «Автопостинг».
+ * Чистый клиент на локальном состоянии: клик по посту убирает его, «+ Добавить» дописывает
+ * новый пост по кругу из заготовок. Позже очередь может грузиться из API автопостинга
+ * (см. backend-задачи и #147) — реальные запросы вне scope этого демо.
+ */
+export function QueueDemo() {
+  const [queue, setQueue] = useState<QueueItem[]>(INITIAL_QUEUE)
+  // Указатель по кругу для новых постов (qNext в макете): стартует с 3 — после стартовых заготовок.
+  const [nextIndex, setNextIndex] = useState(3)
+
+  // Счётчик учитывает только посты «в очереди», без уже опубликованных.
+  const pending = queue.filter((item) => !item.done).length
+
+  const removeItem = (id: string) => {
+    setQueue((items) => items.filter((item) => item.id !== id))
+  }
+
+  const addItem = () => {
+    setQueue((items) => [
+      ...items,
+      {
+        id: `added-${nextIndex}`,
+        networkIndex: nextIndex % NETWORKS.length,
+        label: LABELS[nextIndex % LABELS.length],
+        when: WHENS[nextIndex % WHENS.length],
+        done: false,
+      },
+    ])
+    setNextIndex((value) => value + 1)
+  }
+
+  return (
+    <Card
+      withBorder
+      radius="lg"
+      p={0}
+      style={{
+        borderColor: BORDER,
+        background: '#fff',
+        boxShadow: '0 12px 32px rgba(23,21,15,.08)',
+        overflow: 'hidden',
+      }}
+    >
+      <Group
+        gap={12}
+        align="center"
+        px={18}
+        py={14}
+        wrap="wrap"
+        style={{ borderBottom: `1px solid ${SOFT_BORDER}` }}
+      >
+        <Text fz={15} fw={700}>
+          Очередь публикаций
+        </Text>
+        <Badge
+          radius="xl"
+          variant="light"
+          color="brand"
+          styles={{ root: { textTransform: 'none', fontWeight: 600 } }}
+        >
+          {pending} {plural(pending, ['пост в очереди', 'поста в очереди', 'постов в очереди'])}
+        </Badge>
+        <Text ml="auto" fz={12} c="rgba(23,21,15,.48)">
+          живое демо
+        </Text>
+      </Group>
+
+      <Stack gap={8} px={18} py={14}>
+        {queue.map((item) => {
+          // Код и цвет сети — из общего справочника, статус выводится из флага done.
+          const network = NETWORKS[item.networkIndex]
+          const status = item.done
+            ? { label: 'опубликован', color: '#1E7F4F', bg: 'rgba(34,160,107,.12)' }
+            : { label: 'в очереди', color: 'rgba(23,21,15,.55)', bg: 'rgba(23,21,15,.07)' }
+
+          return (
+            <UnstyledButton
+              key={item.id}
+              title="Нажмите, чтобы убрать из очереди"
+              onClick={() => removeItem(item.id)}
+              px={14}
+              py={10}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 11,
+                width: '100%',
+                background: '#F6F4EF',
+                border: '1px solid rgba(23,21,15,.07)',
+                borderRadius: 10,
+                cursor: 'pointer',
+              }}
+            >
+              <Text
+                fz={9.5}
+                fw={700}
+                c="#fff"
+                ta="center"
+                style={{
+                  background: network.color,
+                  borderRadius: 5,
+                  padding: '3px 6px',
+                  minWidth: 22,
+                  flex: 'none',
+                }}
+              >
+                {network.code}
+              </Text>
+              <Text fz={14} fw={600}>
+                {item.label}
+              </Text>
+              <Text ml="auto" fz={12.5} c="rgba(23,21,15,.55)" style={{ flex: 'none' }}>
+                {item.when}
+              </Text>
+              <Text
+                fz={11}
+                fw={700}
+                style={{
+                  color: status.color,
+                  background: status.bg,
+                  borderRadius: 'var(--mantine-radius-pill)',
+                  padding: '4px 10px',
+                  flex: 'none',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {status.label}
+              </Text>
+            </UnstyledButton>
+          )
+        })}
+
+        <UnstyledButton
+          onClick={addItem}
+          px={11}
+          py={11}
+          ta="center"
+          style={{
+            border: '1.5px dashed rgba(23,21,15,.2)',
+            borderRadius: 10,
+          }}
+        >
+          <Text fz={13.5} fw={600} c="rgba(23,21,15,.5)">
+            + Добавить в очередь
+          </Text>
+        </UnstyledButton>
+      </Stack>
+    </Card>
+  )
+}

--- a/frontend/src/pages/feature-crossposting/ui/CrosspostingPage.tsx
+++ b/frontend/src/pages/feature-crossposting/ui/CrosspostingPage.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom'
 import {
   Anchor,
+  Badge,
   Box,
   Button,
   Card,
@@ -16,6 +17,7 @@ import { MarketingHeader } from '@/widgets/marketing-header'
 import { MarketingFooter } from '@/widgets/marketing-footer'
 import { useAuthModal } from '@/features/auth'
 import type { Icon } from '@tabler/icons-react'
+import { PostPreviewDemo } from './PostPreviewDemo'
 
 interface Capability {
   icon: Icon
@@ -53,9 +55,13 @@ export function CrosspostingPage() {
       <MarketingHeader active="features" />
 
       <Box component="main">
-        {/* Хлебные крошки */}
+        {/* Хлебные крошки: Главная / Возможности / Кросспостинг */}
         <Container size="lg" pt={{ base: 20, sm: 24 }}>
           <Text fz={13} c="dimmed">
+            <Anchor component={Link} to="/" c="dimmed" underline="never" inherit>
+              Главная
+            </Anchor>{' '}
+            /{' '}
             <Anchor component={Link} to="/#features" c="dimmed" underline="never" inherit>
               Возможности
             </Anchor>{' '}
@@ -66,62 +72,70 @@ export function CrosspostingPage() {
           </Text>
         </Container>
 
-        {/* Hero */}
+        {/* Hero: слева текстовый блок, справа демо-превью поста (на мобильном — друг под другом) */}
         <Box component="section" py={{ base: 40, sm: 56 }}>
           <Container size="lg">
-            <Stack gap={0} maw={640}>
-              <Box
-                style={{
-                  display: 'inline-block',
-                  alignSelf: 'flex-start',
-                  background: 'rgba(43,80,236,.08)',
-                  color: '#2B50EC',
-                  borderRadius: 'var(--mantine-radius-pill)',
-                  padding: '6px 12px',
-                  fontSize: 12,
-                  fontWeight: 700,
-                }}
-              >
-                Кросспостинг
-              </Box>
+            <SimpleGrid cols={{ base: 1, md: 2 }} spacing={48} verticalSpacing={40}>
+              <Stack gap={0} justify="center">
+                <Box>
+                  <Badge
+                    radius="xl"
+                    variant="light"
+                    color="brand"
+                    styles={{ root: { textTransform: 'none', fontWeight: 700 } }}
+                  >
+                    Кросспостинг
+                  </Badge>
+                </Box>
 
-              <Text
-                component="h1"
-                mt={16}
-                fz={{ base: 32, sm: 42 }}
-                fw={800}
-                lh={1.1}
-                style={{ letterSpacing: '-.7px' }}
-              >
-                Один пост —{' '}
                 <Text
-                  component="span"
-                  inherit
-                  style={{
-                    background: 'var(--mantine-color-accent-5)',
-                    padding: '0 8px',
-                    borderRadius: 8,
-                  }}
+                  component="h1"
+                  mt={16}
+                  fz={{ base: 32, sm: 42 }}
+                  fw={800}
+                  lh={1.1}
+                  style={{ letterSpacing: '-.7px' }}
                 >
-                  все площадки
-                </Text>{' '}
-                сразу
-              </Text>
+                  Один пост —{' '}
+                  <Text
+                    component="span"
+                    inherit
+                    style={{
+                      background: 'var(--mantine-color-accent-5)',
+                      padding: '0 8px',
+                      borderRadius: 8,
+                    }}
+                  >
+                    все площадки
+                  </Text>{' '}
+                  сразу
+                </Text>
 
-              <Text mt={16} fz={16} lh={1.55} c="rgba(23,21,15,.7)">
-                Напишите текст один раз. Отложка сама адаптирует его под каждую сеть: лимиты
-                символов, форматы, заголовки, кнопки и UTM-метки.
-              </Text>
+                <Text mt={16} fz={16} lh={1.55} c="rgba(23,21,15,.7)">
+                  Напишите текст один раз. Отложка сама адаптирует его под каждую сеть: лимиты
+                  символов, форматы, заголовки, кнопки и UTM-метки.
+                </Text>
 
-              <Group mt={24} gap={12}>
-                <Button size="md" radius="md" color="brand" onClick={() => open('register')}>
-                  Попробовать бесплатно
-                </Button>
-                <Button component={Link} to="/#features" size="md" radius="md" variant="default">
-                  Все возможности
-                </Button>
-              </Group>
-            </Stack>
+                <Group mt={24} gap={12}>
+                  <Button size="md" radius="md" color="brand" onClick={() => open('register')}>
+                    Попробовать бесплатно
+                  </Button>
+                  <Button
+                    component={Link}
+                    to="/features/autoposting"
+                    size="md"
+                    radius="md"
+                    variant="outline"
+                    color="dark"
+                  >
+                    А автопостинг?
+                  </Button>
+                </Group>
+              </Stack>
+
+              {/* Живое демо: превью поста под выбранную площадку */}
+              <PostPreviewDemo />
+            </SimpleGrid>
           </Container>
         </Box>
 

--- a/frontend/src/pages/feature-crossposting/ui/PostPreviewDemo.tsx
+++ b/frontend/src/pages/feature-crossposting/ui/PostPreviewDemo.tsx
@@ -1,0 +1,262 @@
+import { useState } from 'react'
+import { Box, Card, Group, Text, UnstyledButton } from '@mantine/core'
+import { NETWORKS } from '@/shared/config'
+
+const BORDER = 'rgba(23,21,15,.1)'
+const SOFT_BORDER = 'rgba(23,21,15,.09)'
+
+/** Общий текст поста кофейни «Молоко» — базу адаптируем под каждую сеть (как в макете). */
+const BASE_TEXT =
+  'Открыли запись на новогодние капучино-сеты! Бронируйте столик — вечером мест уже не будет.'
+
+interface NetworkPreview {
+  /** Строка под названием сообщества: формат публикации и время. */
+  meta: string
+  /** Заголовок над текстом — только у сетей со «статьями» (Дзен, RUTUBE). */
+  title?: string
+  text: string
+  /** Подпись заглушки медиа-блока. */
+  media: string
+  /** Кнопка внизу карточки — только там, где площадка её поддерживает (Telegram). */
+  btn?: string
+  /** Зелёные чипы-пометки: что «Отложка» адаптировала для этой сети. */
+  chips: string[]
+}
+
+// Мок-данные превью по 7 сетям, ключ — id из общего справочника NETWORKS.
+// Позже данные превью могут приходить с бэкенда — сейчас это осознанный мок,
+// реальная интеграция вне scope этой задачи.
+const PREVIEWS: Record<string, NetworkPreview> = {
+  vk: {
+    meta: 'пост сообщества · сегодня, 12:00',
+    text: `${BASE_TEXT}\n\n#кофейня #новыйгод #капучино`,
+    media: 'фото 1200 × 800',
+    chips: ['Хештеги подставлены', 'UTM-метка в ссылке'],
+  },
+  tg: {
+    meta: 'пост в канале · сегодня, 12:00',
+    text: BASE_TEXT,
+    media: 'фото 1280 × 720',
+    btn: 'Забронировать столик',
+    chips: ['Кнопка-ссылка добавлена', 'Уведомление подписчикам'],
+  },
+  ok: {
+    meta: 'заметка группы · сегодня, 12:00',
+    text: BASE_TEXT,
+    media: 'фото 1200 × 800',
+    chips: ['Формат «заметка с фото»', 'UTM-метка в ссылке'],
+  },
+  max: {
+    meta: 'сообщение в канал · сегодня, 12:00',
+    text: BASE_TEXT,
+    media: 'фото 1080 × 1080',
+    chips: ['Формат под мессенджер'],
+  },
+  dzen: {
+    meta: 'статья · сегодня, 12:05',
+    title: 'Новогодние капучино-сеты уже в меню',
+    text: `${BASE_TEXT} Рассказываем, что внутри сета и как забронировать.`,
+    media: 'обложка 1600 × 900',
+    chips: ['Добавлен заголовок для Дзена', 'Текст расширен до статьи'],
+  },
+  rutube: {
+    meta: 'видео · сегодня, 12:10',
+    title: 'Новогодние сеты: смотрим, что внутри',
+    text: `Описание к видео: ${BASE_TEXT}`,
+    media: 'видео 1920 × 1080 + обложка',
+    chips: ['Заголовок и описание к видео'],
+  },
+  youtube: {
+    meta: 'Shorts · сегодня, 12:10',
+    text: `Описание: ${BASE_TEXT}`,
+    media: 'вертикальное видео 1080 × 1920',
+    chips: ['Формат Shorts', 'Ссылка в описании'],
+  },
+}
+
+/**
+ * Демо «Как пост будет выглядеть на площадке» в hero страницы «Кросспостинг».
+ * Чистая клиентская симуляция на useState: переключение таба сети полностью
+ * перерисовывает превью поста под выбранную площадку. Текст поста рендерится
+ * как текст (React экранирует), без innerHTML — гайдлайн безопасности.
+ */
+export function PostPreviewDemo() {
+  const [activeIndex, setActiveIndex] = useState(0)
+
+  const network = NETWORKS[activeIndex]
+  const preview = PREVIEWS[network.id]
+
+  return (
+    <Card
+      withBorder
+      radius="lg"
+      p={0}
+      style={{
+        borderColor: BORDER,
+        background: '#fff',
+        boxShadow: '0 12px 32px rgba(23,21,15,.08)',
+        overflow: 'hidden',
+      }}
+    >
+      <Group
+        gap={12}
+        align="center"
+        px={18}
+        py={14}
+        wrap="wrap"
+        style={{ borderBottom: `1px solid ${SOFT_BORDER}` }}
+      >
+        <Text fz={15} fw={700}>
+          Как пост будет выглядеть на площадке
+        </Text>
+        <Text ml="auto" fz={12} c="rgba(23,21,15,.48)">
+          живое демо — переключайте
+        </Text>
+      </Group>
+
+      {/* Табы-пилюли по всем 7 сетям: активная заливается брендовым цветом сети */}
+      <Group gap={6} px={18} pt={14} pb={4} wrap="wrap">
+        {NETWORKS.map((net, index) => {
+          const active = index === activeIndex
+          return (
+            <UnstyledButton
+              key={net.id}
+              onClick={() => setActiveIndex(index)}
+              style={{
+                border: `1px solid ${active ? net.color : 'rgba(23,21,15,.15)'}`,
+                background: active ? net.color : '#fff',
+                color: active ? '#fff' : 'rgba(23,21,15,.75)',
+                borderRadius: 'var(--mantine-radius-pill)',
+                padding: '7px 13px',
+                fontSize: 12.5,
+                fontWeight: 600,
+              }}
+            >
+              {net.name}
+            </UnstyledButton>
+          )
+        })}
+      </Group>
+
+      <Box px={18} pt={14} pb={18}>
+        {/* Карточка превью поста кофейни «Молоко» под выбранную сеть */}
+        <Box
+          p={16}
+          style={{
+            background: '#F6F4EF',
+            border: '1px solid rgba(23,21,15,.08)',
+            borderRadius: 12,
+          }}
+        >
+          <Group gap={10} align="center" wrap="nowrap">
+            <Box
+              w={34}
+              h={34}
+              style={{
+                flex: 'none',
+                borderRadius: 'var(--mantine-radius-pill)',
+                background: 'var(--mantine-color-accent-5)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontWeight: 800,
+                fontSize: 14,
+              }}
+            >
+              М
+            </Box>
+            <Box>
+              <Text fz={13.5} fw={700}>
+                Кофейня «Молоко»
+              </Text>
+              <Text fz={11.5} c="rgba(23,21,15,.5)">
+                {preview.meta}
+              </Text>
+            </Box>
+            <Text
+              ml="auto"
+              fz={9.5}
+              fw={700}
+              c="#fff"
+              style={{
+                flex: 'none',
+                background: network.color,
+                borderRadius: 5,
+                padding: '3px 7px',
+              }}
+            >
+              {network.code}
+            </Text>
+          </Group>
+
+          {/* Заголовок — только у сетей, где он задан (Дзен, RUTUBE) */}
+          {preview.title && (
+            <Text mt={12} fz={15.5} fw={700}>
+              {preview.title}
+            </Text>
+          )}
+
+          {/* Текст поста рендерится как текст — без innerHTML (безопасность) */}
+          <Text mt={10} fz={14} lh={1.55} c="rgba(23,21,15,.85)" style={{ whiteSpace: 'pre-line' }}>
+            {preview.text}
+          </Text>
+
+          {/* Заглушка медиа: dashed-рамка с подписью, реальных файлов в демо нет */}
+          <Box
+            mt={12}
+            h={96}
+            style={{
+              border: '1.5px dashed rgba(23,21,15,.18)',
+              borderRadius: 10,
+              background: '#fff',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <Text fz={12} c="rgba(23,21,15,.4)">
+              {preview.media}
+            </Text>
+          </Box>
+
+          {/* Кнопка — только там, где площадка её поддерживает (Telegram) */}
+          {preview.btn && (
+            <Box
+              mt={12}
+              p={9}
+              ta="center"
+              style={{
+                border: `1.5px solid ${network.color}`,
+                color: network.color,
+                borderRadius: 9,
+                fontSize: 13.5,
+                fontWeight: 700,
+              }}
+            >
+              {preview.btn}
+            </Box>
+          )}
+        </Box>
+
+        {/* Зелёные чипы: что «Отложка» адаптировала под выбранную сеть */}
+        <Group gap={6} mt={12} wrap="wrap">
+          {preview.chips.map((chip) => (
+            <Text
+              key={chip}
+              fz={11.5}
+              fw={600}
+              style={{
+                color: '#1E7F4F',
+                background: 'rgba(34,160,107,.1)',
+                borderRadius: 'var(--mantine-radius-pill)',
+                padding: '5px 10px',
+              }}
+            >
+              ✓ {chip}
+            </Text>
+          ))}
+        </Group>
+      </Box>
+    </Card>
+  )
+}

--- a/frontend/src/pages/media/ui/MediaPage.tsx
+++ b/frontend/src/pages/media/ui/MediaPage.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 import {
   Box,
   Button,
@@ -10,7 +10,6 @@ import {
   Stack,
   Text,
   Title,
-  UnstyledButton,
 } from '@mantine/core'
 import { useDisclosure } from '@mantine/hooks'
 import { notifications } from '@mantine/notifications'
@@ -24,6 +23,7 @@ import {
   MEDIA_PREVIEW_FALLBACK,
 } from '@/entities/media'
 import type { Media } from '@/entities/media'
+import { MediaUploadModal } from '@/features/media-upload'
 import { MediaGallery, MediaGallerySkeleton } from '@/widgets/media-gallery'
 import { EmptyState, QueryState } from '@/shared/ui'
 import classes from './MediaPage.module.css'
@@ -41,16 +41,8 @@ export function MediaPage() {
   const [selected, setSelected] = useState<Media | null>(null)
   // Подтверждение удаления (действие необратимо) — отдельная маленькая модалка.
   const [confirmOpened, confirm] = useDisclosure(false)
-  const fileInputRef = useRef<HTMLInputElement>(null)
 
   const deleteMedia = useDeleteMediaMutation()
-
-  // Загрузка — заглушка: реальная отправка появится с Design First.
-  const handleUpload = () => {
-    // TODO (Design First, backlog): POST /media (multipart) + инвалидация mediaKeys.all.
-    notifications.show({ color: 'green', message: 'Файлы загружены в медиатеку (демо)' })
-    upload.close()
-  }
 
   // Удаление после подтверждения: мок-мутация правит кэш, плитка исчезает из сетки сразу.
   const handleConfirmDelete = () => {
@@ -115,46 +107,8 @@ export function MediaPage() {
         </QueryState>
       </Card>
 
-      {/* ===== Загрузка в медиатеку ===== */}
-      <Modal
-        opened={uploadOpened}
-        onClose={upload.close}
-        title="Загрузка в медиатеку"
-        radius="lg"
-        centered
-        styles={{ title: { fontWeight: 800, fontSize: 17, letterSpacing: '-.2px' } }}
-      >
-        <input
-          ref={fileInputRef}
-          type="file"
-          multiple
-          accept="image/jpeg,image/png,video/mp4"
-          hidden
-          onChange={handleUpload}
-        />
-        <UnstyledButton
-          onClick={() => fileInputRef.current?.click()}
-          style={{
-            display: 'block',
-            width: '100%',
-            border: '1.5px dashed rgba(43,80,236,.45)',
-            borderRadius: 12,
-            background: 'rgba(43,80,236,.04)',
-            padding: '30px 16px',
-            textAlign: 'center',
-          }}
-        >
-          <Text fz={13.5} fw={700} c="brand">
-            Перетащите файлы сюда
-          </Text>
-          <Text mt={4} fz={12} c="dimmed">
-            или нажмите, чтобы выбрать · JPG, PNG, MP4 до 2 ГБ
-          </Text>
-        </UnstyledButton>
-        <Button fullWidth mt="md" color="brand" radius="md" onClick={handleUpload}>
-          Готово
-        </Button>
-      </Modal>
+      {/* ===== Загрузка в медиатеку (features/media-upload) ===== */}
+      <MediaUploadModal opened={uploadOpened} onClose={upload.close} />
 
       {/* ===== Предпросмотр медиа ===== */}
       <Modal

--- a/frontend/src/pages/queue/ui/PostStatsModal.tsx
+++ b/frontend/src/pages/queue/ui/PostStatsModal.tsx
@@ -1,11 +1,37 @@
-import { Anchor, Group, Modal, Paper, SimpleGrid, Stack, Text } from '@mantine/core'
-import { IconExternalLink } from '@tabler/icons-react'
+import { useEffect, useState } from 'react'
+import { Anchor, Group, Modal, Paper, SimpleGrid, Skeleton, Stack, Text } from '@mantine/core'
 import { NETWORKS } from '@/shared/config'
 import { NetworkPill } from '@/shared/ui'
 import { formatDateTime } from '@/shared/lib'
-import type { Post } from '@/entities/scheduled-post'
+import type { Post, PostMetrics } from '@/entities/scheduled-post'
 
 const NETWORK_BY_ID = new Map(NETWORKS.map((n) => [n.id, n]))
+
+/** Кремовая подложка плиток и текста поста (макет app-dashboard, «Статистика поста»). */
+const PANEL_BG = '#F6F4EF'
+/** Акцент плитки ER: зелёная подложка и тёмно-зелёное число. */
+const ER_BG = 'rgba(34, 160, 107, 0.1)'
+const ER_COLOR = '#1E7F4F'
+
+/**
+ * Переходы и ER отправленных постов (#196). Поля clicks/er должны жить
+ * в PostMetrics — сущность entities/scheduled-post дорабатывается отдельно,
+ * поэтому до её обновления значения замоканы локально; одноимённые поля
+ * из сущности имеют приоритет, как только появятся (см. getExtendedMetrics).
+ */
+const EXTRA_METRICS: Record<string, { clicks: number; er: string }> = {
+  'sp-sent-1': { clicks: 342, er: '3.5%' },
+  'sp-sent-2': { clicks: 261, er: '5.8%' },
+  'sp-sent-3': { clicks: 148, er: '3.6%' },
+  'sp-sent-4': { clicks: 517, er: '5.6%' },
+}
+
+/** clicks/er: из сущности, если поля уже добавлены в PostMetrics; иначе — локальный мок. */
+function getExtendedMetrics(post: Post): { clicks?: number; er?: string } {
+  const entity = post.metrics as (PostMetrics & { clicks?: number; er?: string }) | undefined
+  const fallback = EXTRA_METRICS[post.id]
+  return { clicks: entity?.clicks ?? fallback?.clicks, er: entity?.er ?? fallback?.er }
+}
 
 interface PostStatsModalProps {
   post: Post | null
@@ -14,17 +40,19 @@ interface PostStatsModalProps {
 }
 
 interface MetricCellProps {
-  value: number
+  value: string
   label: string
+  /** Акцентная плитка (ER): зелёный фон и зелёное число. */
+  accent?: boolean
 }
 
-function MetricCell({ value, label }: MetricCellProps) {
+function MetricCell({ value, label, accent = false }: MetricCellProps) {
   return (
-    <Paper bg="gray.0" radius="md" p="sm">
-      <Text fz={19} fw={800}>
-        {value.toLocaleString('ru-RU')}
+    <Paper radius={11} p={12} style={{ background: accent ? ER_BG : PANEL_BG }}>
+      <Text fz={19} fw={800} style={accent ? { color: ER_COLOR } : undefined}>
+        {value}
       </Text>
-      <Text size="xs" c="dimmed" mt={2}>
+      <Text fz={11} mt={2} style={{ color: 'rgba(23, 21, 15, 0.5)' }}>
         {label}
       </Text>
     </Paper>
@@ -35,11 +63,31 @@ function MetricCell({ value, label }: MetricCellProps) {
 export function PostStatsModal({ post, opened, onClose }: PostStatsModalProps) {
   const network = post ? NETWORK_BY_ID.get(post.networkIds[0]) : undefined
   const metrics = post?.metrics
+  const extended = post ? getExtendedMetrics(post) : undefined
+
+  // Имитация загрузки статистики (~600 мс, как в остальных моках): реальный
+  // GET /posts/{id}/stats подключается отдельной backend-задачей (#147).
+  // Храним id поста, для которого «загрузка» завершилась; при закрытии сбрасываем,
+  // чтобы каждое открытие модалки снова показывало скелетоны.
+  const [loadedId, setLoadedId] = useState<string | null>(null)
+  const postId = post?.id
+  const isLoading = postId != null && loadedId !== postId
+
+  useEffect(() => {
+    if (!opened || postId == null) return undefined
+    const timer = window.setTimeout(() => setLoadedId(postId), 600)
+    return () => window.clearTimeout(timer)
+  }, [opened, postId])
+
+  const handleClose = () => {
+    setLoadedId(null)
+    onClose()
+  }
 
   return (
     <Modal
       opened={opened}
-      onClose={onClose}
+      onClose={handleClose}
       size="lg"
       radius="lg"
       title={
@@ -57,28 +105,44 @@ export function PostStatsModal({ post, opened, onClose }: PostStatsModalProps) {
             {network?.name} · опубликован {formatDateTime(post.scheduledAt)}
           </Text>
 
-          <Paper bg="gray.0" radius="md" p="md">
-            <Text size="sm" style={{ lineHeight: 1.55 }}>
+          <Paper radius={12} p={14} style={{ background: PANEL_BG }}>
+            <Text fz={13.5} style={{ lineHeight: 1.55, color: 'rgba(23, 21, 15, 0.8)' }}>
               {post.text}
             </Text>
           </Paper>
 
-          {metrics ? (
-            <SimpleGrid cols={{ base: 2, xs: 4 }} spacing="sm">
-              <MetricCell value={metrics.views} label="просмотры" />
-              <MetricCell value={metrics.likes} label="лайки" />
-              <MetricCell value={metrics.reposts} label="репосты" />
-              <MetricCell value={metrics.comments} label="комментарии" />
+          {isLoading ? (
+            <SimpleGrid cols={3} spacing={10}>
+              {Array.from({ length: 6 }, (_, index) => (
+                <Skeleton key={index} height={64} radius={11} />
+              ))}
             </SimpleGrid>
-          ) : null}
+          ) : metrics ? (
+            <SimpleGrid cols={3} spacing={10}>
+              <MetricCell value={metrics.views.toLocaleString('ru-RU')} label="просмотры" />
+              <MetricCell value={metrics.likes.toLocaleString('ru-RU')} label="лайки" />
+              <MetricCell value={metrics.reposts.toLocaleString('ru-RU')} label="репосты" />
+              <MetricCell value={metrics.comments.toLocaleString('ru-RU')} label="комментарии" />
+              <MetricCell
+                value={extended?.clicks != null ? extended.clicks.toLocaleString('ru-RU') : '—'}
+                label="переходы"
+              />
+              {/* ER выводим строкой как есть — на фронте не пересчитываем. */}
+              <MetricCell value={extended?.er ?? '—'} label="ER" accent />
+            </SimpleGrid>
+          ) : (
+            <Text size="sm" c="dimmed" ta="center" py="md">
+              Не удалось загрузить статистику
+            </Text>
+          )}
 
-          <Group justify="flex-end">
+          <Group justify="space-between" gap="sm">
+            <Text fz={12} style={{ color: 'rgba(23, 21, 15, 0.45)' }}>
+              UTM-метка: utm_source={post.networkIds[0]}
+            </Text>
             {/* TODO (Design First): реальная ссылка из GET /posts/{id} (поле publishedUrl). */}
-            <Anchor href="#" fw={700} c="brand" onClick={(e) => e.preventDefault()}>
-              <Group gap={4} wrap="nowrap">
-                Открыть на площадке
-                <IconExternalLink size={16} />
-              </Group>
+            <Anchor href="#" fz={13} fw={700} c="brand" onClick={(event) => event.preventDefault()}>
+              Открыть на площадке →
             </Anchor>
           </Group>
         </Stack>

--- a/frontend/src/pages/queue/ui/QueuePage.module.css
+++ b/frontend/src/pages/queue/ui/QueuePage.module.css
@@ -1,0 +1,26 @@
+/* Переключатель вкладок очереди по макету app-dashboard:
+   белая подложка с рамкой, активная вкладка — тёмная заливка с белым текстом. */
+
+.tabsList {
+  /* Переменные Mantine variant="pills": заливка и текст активной вкладки. */
+  --tabs-color: #17150f;
+  --tabs-text-color: #fff;
+
+  gap: 4px;
+  width: fit-content;
+  padding: 4px;
+  background: #fff;
+  border: 1px solid rgba(23, 21, 15, 0.12);
+  border-radius: 11px;
+}
+
+.tab {
+  /* Неактивная вкладка: прозрачный фон, приглушённый тёмный текст. */
+  --tab-color: rgba(23, 21, 15, 0.7);
+  --tab-hover-color: rgba(23, 21, 15, 0.05);
+
+  padding: 7px 14px;
+  font-size: 12.5px;
+  font-weight: 600;
+  border-radius: 8px;
+}

--- a/frontend/src/pages/queue/ui/QueuePage.tsx
+++ b/frontend/src/pages/queue/ui/QueuePage.tsx
@@ -1,6 +1,17 @@
 import { useState } from 'react'
+import type { CSSProperties } from 'react'
 import { useDisclosure } from '@mantine/hooks'
-import { Badge, Box, Group, Paper, Stack, Tabs, Text, Title, UnstyledButton } from '@mantine/core'
+import {
+  Box,
+  Group,
+  Paper,
+  Skeleton,
+  Stack,
+  Tabs,
+  Text,
+  Title,
+  UnstyledButton,
+} from '@mantine/core'
 import dayjs from 'dayjs'
 import { NETWORKS } from '@/shared/config'
 import { EmptyState, NetworkPill } from '@/shared/ui'
@@ -8,15 +19,97 @@ import { useAppModals } from '@/features/app-modals'
 import { useQueue } from '@/entities/scheduled-post'
 import type { Post } from '@/entities/scheduled-post'
 import { PostStatsModal } from './PostStatsModal'
+import classes from './QueuePage.module.css'
 
 const NETWORK_BY_ID = new Map(NETWORKS.map((n) => [n.id, n]))
 
+/** Период фильтрации списков очереди (неделя ⊂ месяц ⊂ квартал ⊂ год). */
+type QueuePeriod = 'week' | 'month' | 'quarter' | 'year'
+
+const PERIOD_OPTIONS: { value: QueuePeriod; label: string }[] = [
+  { value: 'week', label: 'Неделя' },
+  { value: 'month', label: 'Месяц' },
+  { value: 'quarter', label: 'Квартал' },
+  { value: 'year', label: 'Год' },
+]
+
+/** Границы периодов в днях от текущего момента. */
+const PERIOD_DAYS: Record<QueuePeriod, number> = { week: 7, month: 31, quarter: 92, year: 366 }
+
+/** Пост попадает в период, если его дата не дальше границы от «сейчас» (в обе стороны). */
+function isWithinPeriod(post: Post, period: QueuePeriod): boolean {
+  return Math.abs(dayjs(post.scheduledAt).diff(dayjs(), 'day')) <= PERIOD_DAYS[period]
+}
+
+/** Сокращённые дни недели с заглавной буквы — формат времени очереди «Пн, 09:00». */
+const WEEKDAYS_SHORT = ['Вс', 'Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб']
+
+function formatQueueTime(iso: string): string {
+  const date = dayjs(iso)
+  return `${WEEKDAYS_SHORT[date.day()]}, ${date.format('HH:mm')}`
+}
+
+/** Сокращённые месяцы для метки недели («10–16 ноя»). */
+const MONTHS_SHORT = [
+  'янв',
+  'фев',
+  'мар',
+  'апр',
+  'мая',
+  'июн',
+  'июл',
+  'авг',
+  'сен',
+  'окт',
+  'ноя',
+  'дек',
+]
+
+/** Диапазон ISO-недели поста: «10–16 ноя», на стыке месяцев — «29 июн – 5 июл». */
+function formatWeekLabel(iso: string): string {
+  const date = dayjs(iso)
+  // Понедельник вычисляем явно, не полагаясь на weekStart текущей локали dayjs.
+  const monday = date.subtract((date.day() + 6) % 7, 'day')
+  const sunday = monday.add(6, 'day')
+  if (monday.month() === sunday.month()) {
+    return `${monday.date()}–${sunday.date()} ${MONTHS_SHORT[sunday.month()]}`
+  }
+  return `${monday.date()} ${MONTHS_SHORT[monday.month()]} – ${sunday.date()} ${MONTHS_SHORT[sunday.month()]}`
+}
+
+/** Общий стиль строки списка по макету: кремовая подложка, скругление 10. */
+const ROW_STYLE: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 11,
+  width: '100%',
+  background: '#F6F4EF',
+  border: '1px solid rgba(23, 21, 15, 0.07)',
+  borderRadius: 10,
+  padding: '10px 14px',
+}
+
 /** Экран «Очередь»: вкладки «В очереди» и «Отправленные». */
 export function QueuePage() {
-  const { upcoming, sent } = useQueue()
+  const queue = useQueue()
+  // Флаг загрузки появится в useQueue после перевода мока на асинхронную выборку
+  // (задача по entities/scheduled-post); до неё поле отсутствует и флаг всегда false.
+  const {
+    upcoming,
+    sent,
+    isLoading = false,
+  } = queue as ReturnType<typeof useQueue> & { isLoading?: boolean }
   const { openComposer } = useAppModals()
   const [statsPost, setStatsPost] = useState<Post | null>(null)
   const [statsOpened, statsHandlers] = useDisclosure(false)
+  // Период — отдельный для каждой карточки (как в макете: queuePer / archPer).
+  const [upcomingPeriod, setUpcomingPeriod] = useState<QueuePeriod>('week')
+  const [sentPeriod, setSentPeriod] = useState<QueuePeriod>('week')
+
+  // Фильтр по периоду живёт на странице: мок useQueue пока не принимает параметров
+  // (переход на выборку с периодом — задача по entities/scheduled-post).
+  const upcomingFiltered = upcoming.filter((post) => isWithinPeriod(post, upcomingPeriod))
+  const sentFiltered = sent.filter((post) => isWithinPeriod(post, sentPeriod))
 
   const openStats = (post: Post) => {
     setStatsPost(post)
@@ -29,10 +122,14 @@ export function QueuePage() {
         Очередь
       </Title>
 
-      <Tabs defaultValue="upcoming">
+      <Tabs
+        defaultValue="upcoming"
+        variant="pills"
+        classNames={{ list: classes.tabsList, tab: classes.tab }}
+      >
         <Tabs.List>
-          <Tabs.Tab value="upcoming">В очереди · {upcoming.length}</Tabs.Tab>
-          <Tabs.Tab value="sent">Отправленные · {sent.length}</Tabs.Tab>
+          <Tabs.Tab value="upcoming">В очереди · {upcomingFiltered.length}</Tabs.Tab>
+          <Tabs.Tab value="sent">Отправленные · {sentFiltered.length}</Tabs.Tab>
         </Tabs.List>
 
         <Tabs.Panel value="upcoming" pt="md">
@@ -43,16 +140,22 @@ export function QueuePage() {
               style={{ borderBottom: '1px solid var(--mantine-color-gray-2)' }}
             >
               <Text fw={700}>Ближайшие публикации</Text>
+              <PeriodChips value={upcomingPeriod} onChange={setUpcomingPeriod} />
               <Text size="sm" c="dimmed" style={{ marginLeft: 'auto' }}>
                 клик по строке — настройки поста
               </Text>
             </Group>
-            {upcoming.length === 0 ? (
-              <EmptyState title="Очередь пуста" description="Запланируйте пост в контент-плане." />
+            {isLoading ? (
+              <RowsSkeleton />
+            ) : upcomingFiltered.length === 0 ? (
+              <EmptyState
+                title="Пока нет запланированных публикаций"
+                description="Запланируйте пост в контент-плане."
+              />
             ) : (
               <Box style={{ overflowX: 'auto' }}>
                 <Stack gap="xs" p="md" style={{ minWidth: 520 }}>
-                  {upcoming.map((post) => (
+                  {upcomingFiltered.map((post) => (
                     <QueueRow key={post.id} post={post} onClick={() => openComposer(post.id)} />
                   ))}
                 </Stack>
@@ -69,19 +172,19 @@ export function QueuePage() {
               style={{ borderBottom: '1px solid var(--mantine-color-gray-2)' }}
             >
               <Text fw={700}>Архив отправленных</Text>
+              <PeriodChips value={sentPeriod} onChange={setSentPeriod} />
               <Text size="sm" c="dimmed" style={{ marginLeft: 'auto' }}>
                 клик по строке — статистика поста
               </Text>
             </Group>
-            {sent.length === 0 ? (
-              <EmptyState
-                title="Пока ничего не отправлено"
-                description="Здесь появятся опубликованные посты."
-              />
+            {isLoading ? (
+              <RowsSkeleton />
+            ) : sentFiltered.length === 0 ? (
+              <EmptyState title="Архив пуст" description="Здесь появятся опубликованные посты." />
             ) : (
               <Box style={{ overflowX: 'auto' }}>
                 <Stack gap="xs" p="md" style={{ minWidth: 520 }}>
-                  {sent.map((post) => (
+                  {sentFiltered.map((post) => (
                     <SentRow key={post.id} post={post} onClick={() => openStats(post)} />
                   ))}
                 </Stack>
@@ -96,6 +199,54 @@ export function QueuePage() {
   )
 }
 
+interface PeriodChipsProps {
+  value: QueuePeriod
+  onChange: (value: QueuePeriod) => void
+}
+
+/** Фильтр-чипы периода «Неделя / Месяц / Квартал / Год» в шапке карточки. */
+function PeriodChips({ value, onChange }: PeriodChipsProps) {
+  return (
+    <Group
+      gap={3}
+      p={3}
+      wrap="nowrap"
+      style={{ background: 'rgba(23, 21, 15, 0.05)', borderRadius: 9 }}
+    >
+      {PERIOD_OPTIONS.map((option) => {
+        const active = option.value === value
+        return (
+          <UnstyledButton
+            key={option.value}
+            onClick={() => onChange(option.value)}
+            style={{
+              borderRadius: 7,
+              padding: '5px 11px',
+              fontSize: 11.5,
+              fontWeight: 600,
+              background: active ? '#17150F' : 'transparent',
+              color: active ? '#fff' : 'rgba(23, 21, 15, 0.7)',
+            }}
+          >
+            {option.label}
+          </UnstyledButton>
+        )
+      })}
+    </Group>
+  )
+}
+
+/** Строки-скелетоны на время загрузки списка. */
+function RowsSkeleton() {
+  return (
+    <Stack gap="xs" p="md">
+      {Array.from({ length: 5 }, (_, index) => (
+        <Skeleton key={index} height={44} radius={10} />
+      ))}
+    </Stack>
+  )
+}
+
 interface RowProps {
   post: Post
   onClick: () => void
@@ -104,25 +255,27 @@ interface RowProps {
 function QueueRow({ post, onClick }: RowProps) {
   const network = NETWORK_BY_ID.get(post.networkIds[0])
   return (
-    <UnstyledButton
-      onClick={onClick}
-      title="Открыть настройки поста"
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 11,
-        background: 'var(--mantine-color-gray-0)',
-        border: '1px solid var(--mantine-color-gray-2)',
-        borderRadius: 10,
-        padding: '10px 14px',
-      }}
-    >
+    <UnstyledButton onClick={onClick} title="Открыть настройки поста" style={ROW_STYLE}>
       {network ? <NetworkPill network={network} variant="badge" /> : null}
       <Text size="sm" fw={600} lineClamp={1} style={{ flex: 1, minWidth: 0 }}>
         {post.title}
       </Text>
       <Text size="sm" c="dimmed" style={{ flexShrink: 0 }}>
-        {dayjs(post.scheduledAt).format('D MMM, HH:mm')}
+        {formatQueueTime(post.scheduledAt)}
+      </Text>
+      <Text
+        component="span"
+        fz={11}
+        fw={600}
+        style={{
+          flexShrink: 0,
+          color: 'rgba(23, 21, 15, 0.45)',
+          background: 'rgba(23, 21, 15, 0.06)',
+          borderRadius: 'var(--mantine-radius-pill)',
+          padding: '3px 9px',
+        }}
+      >
+        {formatWeekLabel(post.scheduledAt)}
       </Text>
     </UnstyledButton>
   )
@@ -131,19 +284,7 @@ function QueueRow({ post, onClick }: RowProps) {
 function SentRow({ post, onClick }: RowProps) {
   const network = NETWORK_BY_ID.get(post.networkIds[0])
   return (
-    <UnstyledButton
-      onClick={onClick}
-      title="Статистика поста"
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 11,
-        background: 'var(--mantine-color-gray-0)',
-        border: '1px solid var(--mantine-color-gray-2)',
-        borderRadius: 10,
-        padding: '10px 14px',
-      }}
-    >
+    <UnstyledButton onClick={onClick} title="Статистика поста" style={ROW_STYLE}>
       {network ? <NetworkPill network={network} variant="badge" /> : null}
       <Text size="sm" fw={600} lineClamp={1} style={{ flex: 1, minWidth: 0 }}>
         {post.title}
@@ -156,9 +297,20 @@ function SentRow({ post, onClick }: RowProps) {
           {post.metrics.views.toLocaleString('ru-RU')}
         </Text>
       ) : null}
-      <Badge color="teal" variant="light" radius="xl" style={{ flexShrink: 0 }}>
+      <Text
+        component="span"
+        fz={11}
+        fw={700}
+        style={{
+          flexShrink: 0,
+          color: '#1E7F4F',
+          background: 'rgba(34, 160, 107, 0.12)',
+          borderRadius: 'var(--mantine-radius-pill)',
+          padding: '3px 9px',
+        }}
+      >
         опубликован
-      </Badge>
+      </Text>
     </UnstyledButton>
   )
 }


### PR DESCRIPTION
Closes #198

Стек: после PR #199-media-preview.

- **@mantine/dropzone ^7.17.8** добавлен в dependencies (+package-lock)
- `features/media-upload` (MediaUploadModal): мульти-дроп, пофайловые Loader→галочка, счётчик «✓ Загружено в этой сессии: N файлов» со сбросом при закрытии, reject-нотификация с форматами
- `features/attach-media` (AttachMediaModal): kind photo/video/cover, одиночный дроп → onSelect(mediaId), блок «Или выберите из медиатеки»; **пока не смонтирована в композер** — публичный API готов (`<AttachMediaModal opened kind onClose onSelect />`), подключение к композеру — небольшой follow-up
- Общие куски в entities/media: UploadDropzone, uploadConfig (лимиты/форматы/подписи), useUploadMediaMutation (мок 900мс, превью через createObjectURL)
- Починен реальный баг: параллельные mutate() одного useMutation перекрывали колбэки — заменено на mutateAsync
- Примечание: issue предлагала shared/ui|lib|config для общих кусков — они в entities/media (изоляция зон при параллельной разработке); перенос — механический follow-up

Проверено агентом вживую: дроп 2+3 файлов, счётчик и склонения, отклонение PDF, новые плитки в сетке. lint/tsc/build чисто.