### PR TITLE
feat(frontend): статистика поста — 6 метрик, переходы и ER, UTM, loading/error

### DIFF
--- a/frontend/src/pages/feature-autoposting/lib/plural.ts
+++ b/frontend/src/pages/feature-autoposting/lib/plural.ts
@@ -1,0 +1,13 @@
+/**
+ * Склонение русских существительных по числу: plural(1|2|5, ['пост', 'поста', 'постов']).
+ * Формула — как в интерактивном макете (docs/design/mockups/feature-autoposting.html).
+ * Кандидат на перенос в shared/lib, как только утилита понадобится другим слайсам.
+ */
+export function plural(n: number, forms: [string, string, string]): string {
+  const a = Math.abs(n) % 100
+  const b = a % 10
+  if (a > 10 && a < 20) return forms[2]
+  if (b > 1 && b < 5) return forms[1]
+  if (b === 1) return forms[0]
+  return forms[2]
+}

--- a/frontend/src/pages/feature-autoposting/ui/AutopostingPage.tsx
+++ b/frontend/src/pages/feature-autoposting/ui/AutopostingPage.tsx
@@ -17,6 +17,7 @@ import type { Icon } from '@tabler/icons-react'
 import { MarketingHeader } from '@/widgets/marketing-header'
 import { MarketingFooter } from '@/widgets/marketing-footer'
 import { useAuthModal } from '@/features/auth'
+import { QueueDemo } from './QueueDemo'
 
 const BORDER = 'rgba(23,21,15,.1)'
 const SOFT_BORDER = 'rgba(23,21,15,.09)'
@@ -45,64 +46,6 @@ const FEATURES: FeatureCard[] = [
   },
 ]
 
-interface QueueItem {
-  short: string
-  color: string
-  label: string
-  when: string
-  status: string
-  statusColor: string
-  statusBg: string
-}
-
-const QUEUE: QueueItem[] = [
-  {
-    short: 'ВК',
-    color: '#0077FF',
-    label: 'Анонс акции',
-    when: 'вт, 09:00',
-    status: 'опубликован',
-    statusColor: '#1E7F4F',
-    statusBg: 'rgba(34,160,107,.12)',
-  },
-  {
-    short: 'TG',
-    color: '#27A6E5',
-    label: 'Утренний дайджест',
-    when: 'вт, 09:05',
-    status: 'опубликован',
-    statusColor: '#1E7F4F',
-    statusBg: 'rgba(34,160,107,.12)',
-  },
-  {
-    short: 'Дз',
-    color: '#1E1E20',
-    label: 'Лонгрид про тренды',
-    when: 'ср, 12:00',
-    status: 'в очереди',
-    statusColor: 'rgba(23,21,15,.55)',
-    statusBg: 'rgba(23,21,15,.07)',
-  },
-  {
-    short: 'ОК',
-    color: '#F7931E',
-    label: 'Опрос для подписчиков',
-    when: 'чт, 19:00',
-    status: 'в очереди',
-    statusColor: 'rgba(23,21,15,.55)',
-    statusBg: 'rgba(23,21,15,.07)',
-  },
-  {
-    short: 'YT',
-    color: '#FF0000',
-    label: 'Шортс: бэкстейдж',
-    when: 'пт, 18:00',
-    status: 'в очереди',
-    statusColor: 'rgba(23,21,15,.55)',
-    statusBg: 'rgba(23,21,15,.07)',
-  },
-]
-
 export function AutopostingPage() {
   const { open } = useAuthModal()
 
@@ -110,9 +53,18 @@ export function AutopostingPage() {
     <Box style={{ background: '#F6F4EF', color: '#17150F' }}>
       <MarketingHeader active="features" />
 
-      {/* Хлебные крошки */}
+      {/* Хлебные крошки: Главная / Возможности / Автопостинг */}
       <Container size="lg" pt={{ base: 20, sm: 28 }}>
         <Text fz={13} c="rgba(23,21,15,.5)">
+          <Text
+            component={Link}
+            to="/"
+            inherit
+            style={{ color: 'inherit', textDecoration: 'none' }}
+          >
+            Главная
+          </Text>{' '}
+          /{' '}
           <Text
             component={Link}
             to="/#features"
@@ -173,7 +125,7 @@ export function AutopostingPage() {
                 </Button>
                 <Button
                   component={Link}
-                  to="/#features"
+                  to="/features/crossposting"
                   size="md"
                   radius="md"
                   variant="outline"
@@ -184,110 +136,8 @@ export function AutopostingPage() {
               </Group>
             </Stack>
 
-            {/* Живое демо: очередь публикаций (статичное представление) */}
-            <Card
-              withBorder
-              radius="lg"
-              p={0}
-              style={{
-                borderColor: BORDER,
-                background: '#fff',
-                boxShadow: '0 12px 32px rgba(23,21,15,.08)',
-                overflow: 'hidden',
-              }}
-            >
-              <Group
-                gap={12}
-                align="center"
-                px={18}
-                py={14}
-                wrap="wrap"
-                style={{ borderBottom: `1px solid ${SOFT_BORDER}` }}
-              >
-                <Text fz={15} fw={700}>
-                  Очередь публикаций
-                </Text>
-                <Badge
-                  radius="xl"
-                  variant="light"
-                  color="brand"
-                  styles={{ root: { textTransform: 'none', fontWeight: 600 } }}
-                >
-                  3 поста в очереди
-                </Badge>
-                <Text ml="auto" fz={12} c="rgba(23,21,15,.48)">
-                  живое демо
-                </Text>
-              </Group>
-
-              <Stack gap={8} px={18} py={14}>
-                {QUEUE.map((item) => (
-                  <Group
-                    key={`${item.short}-${item.label}`}
-                    gap={11}
-                    wrap="nowrap"
-                    align="center"
-                    px={14}
-                    py={10}
-                    style={{
-                      background: '#F6F4EF',
-                      border: `1px solid rgba(23,21,15,.07)`,
-                      borderRadius: 10,
-                    }}
-                  >
-                    <Text
-                      fz={9.5}
-                      fw={700}
-                      c="#fff"
-                      ta="center"
-                      style={{
-                        background: item.color,
-                        borderRadius: 5,
-                        padding: '3px 6px',
-                        minWidth: 22,
-                        flex: 'none',
-                      }}
-                    >
-                      {item.short}
-                    </Text>
-                    <Text fz={14} fw={600}>
-                      {item.label}
-                    </Text>
-                    <Text ml="auto" fz={12.5} c="rgba(23,21,15,.55)" style={{ flex: 'none' }}>
-                      {item.when}
-                    </Text>
-                    <Text
-                      fz={11}
-                      fw={700}
-                      style={{
-                        color: item.statusColor,
-                        background: item.statusBg,
-                        borderRadius: 'var(--mantine-radius-pill)',
-                        padding: '4px 10px',
-                        flex: 'none',
-                        whiteSpace: 'nowrap',
-                      }}
-                    >
-                      {item.status}
-                    </Text>
-                  </Group>
-                ))}
-
-                <Box
-                  px={11}
-                  py={11}
-                  ta="center"
-                  style={{
-                    border: '1.5px dashed rgba(23,21,15,.2)',
-                    borderRadius: 10,
-                  }}
-                >
-                  <Text fz={13.5} fw={600} c="rgba(23,21,15,.5)">
-                    + Добавить в очередь
-                  </Text>
-                </Box>
-              </Stack>
-            </Card>
+            {/* Живое демо: интерактивная очередь публикаций на локальном состоянии */}
+            <QueueDemo />
           </SimpleGrid>
         </Container>
       </Box>

--- a/frontend/src/pages/feature-autoposting/ui/QueueDemo.tsx
+++ b/frontend/src/pages/feature-autoposting/ui/QueueDemo.tsx
@@ -1,0 +1,189 @@
+import { useState } from 'react'
+import { Badge, Card, Group, Stack, Text, UnstyledButton } from '@mantine/core'
+import { NETWORKS } from '@/shared/config'
+import { plural } from '../lib/plural'
+
+const BORDER = 'rgba(23,21,15,.1)'
+const SOFT_BORDER = 'rgba(23,21,15,.09)'
+
+interface QueueItem {
+  /** Уникальный ключ для React (посты из заготовок могут повторяться). */
+  id: string
+  /** Индекс сети в общем справочнике NETWORKS (shared/config). */
+  networkIndex: number
+  label: string
+  when: string
+  /** true — пост уже опубликован, false — ещё ждёт в очереди. */
+  done: boolean
+}
+
+// Стартовая очередь — как в макете feature-autoposting: два поста опубликованы, три ждут.
+const INITIAL_QUEUE: QueueItem[] = [
+  { id: 'seed-1', networkIndex: 0, label: 'Анонс акции', when: 'вт, 09:00', done: true },
+  { id: 'seed-2', networkIndex: 1, label: 'Утренний дайджест', when: 'вт, 09:05', done: true },
+  { id: 'seed-3', networkIndex: 4, label: 'Лонгрид про тренды', when: 'ср, 12:00', done: false },
+  { id: 'seed-4', networkIndex: 2, label: 'Опрос для подписчиков', when: 'чт, 19:00', done: false },
+  { id: 'seed-5', networkIndex: 6, label: 'Шортс: бэкстейдж', when: 'пт, 18:00', done: false },
+]
+
+// Заготовки подписей и времён: новые посты берутся из них по кругу (как LABELS/WHENS в макете).
+const LABELS = [
+  'Анонс акции',
+  'Подборка советов',
+  'Опрос для подписчиков',
+  'Дайджест недели',
+  'Бэкстейдж',
+]
+const WHENS = ['сб, 12:00', 'сб, 15:00', 'вс, 10:00', 'вс, 19:00', 'пн, 09:00']
+
+/**
+ * Интерактивное демо «Очередь публикаций» в hero страницы «Автопостинг».
+ * Чистый клиент на локальном состоянии: клик по посту убирает его, «+ Добавить» дописывает
+ * новый пост по кругу из заготовок. Позже очередь может грузиться из API автопостинга
+ * (см. backend-задачи и #147) — реальные запросы вне scope этого демо.
+ */
+export function QueueDemo() {
+  const [queue, setQueue] = useState<QueueItem[]>(INITIAL_QUEUE)
+  // Указатель по кругу для новых постов (qNext в макете): стартует с 3 — после стартовых заготовок.
+  const [nextIndex, setNextIndex] = useState(3)
+
+  // Счётчик учитывает только посты «в очереди», без уже опубликованных.
+  const pending = queue.filter((item) => !item.done).length
+
+  const removeItem = (id: string) => {
+    setQueue((items) => items.filter((item) => item.id !== id))
+  }
+
+  const addItem = () => {
+    setQueue((items) => [
+      ...items,
+      {
+        id: `added-${nextIndex}`,
+        networkIndex: nextIndex % NETWORKS.length,
+        label: LABELS[nextIndex % LABELS.length],
+        when: WHENS[nextIndex % WHENS.length],
+        done: false,
+      },
+    ])
+    setNextIndex((value) => value + 1)
+  }
+
+  return (
+    <Card
+      withBorder
+      radius="lg"
+      p={0}
+      style={{
+        borderColor: BORDER,
+        background: '#fff',
+        boxShadow: '0 12px 32px rgba(23,21,15,.08)',
+        overflow: 'hidden',
+      }}
+    >
+      <Group
+        gap={12}
+        align="center"
+        px={18}
+        py={14}
+        wrap="wrap"
+        style={{ borderBottom: `1px solid ${SOFT_BORDER}` }}
+      >
+        <Text fz={15} fw={700}>
+          Очередь публикаций
+        </Text>
+        <Badge
+          radius="xl"
+          variant="light"
+          color="brand"
+          styles={{ root: { textTransform: 'none', fontWeight: 600 } }}
+        >
+          {pending} {plural(pending, ['пост в очереди', 'поста в очереди', 'постов в очереди'])}
+        </Badge>
+        <Text ml="auto" fz={12} c="rgba(23,21,15,.48)">
+          живое демо
+        </Text>
+      </Group>
+
+      <Stack gap={8} px={18} py={14}>
+        {queue.map((item) => {
+          // Код и цвет сети — из общего справочника, статус выводится из флага done.
+          const network = NETWORKS[item.networkIndex]
+          const status = item.done
+            ? { label: 'опубликован', color: '#1E7F4F', bg: 'rgba(34,160,107,.12)' }
+            : { label: 'в очереди', color: 'rgba(23,21,15,.55)', bg: 'rgba(23,21,15,.07)' }
+
+          return (
+            <UnstyledButton
+              key={item.id}
+              title="Нажмите, чтобы убрать из очереди"
+              onClick={() => removeItem(item.id)}
+              px={14}
+              py={10}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 11,
+                width: '100%',
+                background: '#F6F4EF',
+                border: '1px solid rgba(23,21,15,.07)',
+                borderRadius: 10,
+                cursor: 'pointer',
+              }}
+            >
+              <Text
+                fz={9.5}
+                fw={700}
+                c="#fff"
+                ta="center"
+                style={{
+                  background: network.color,
+                  borderRadius: 5,
+                  padding: '3px 6px',
+                  minWidth: 22,
+                  flex: 'none',
+                }}
+              >
+                {network.code}
+              </Text>
+              <Text fz={14} fw={600}>
+                {item.label}
+              </Text>
+              <Text ml="auto" fz={12.5} c="rgba(23,21,15,.55)" style={{ flex: 'none' }}>
+                {item.when}
+              </Text>
+              <Text
+                fz={11}
+                fw={700}
+                style={{
+                  color: status.color,
+                  background: status.bg,
+                  borderRadius: 'var(--mantine-radius-pill)',
+                  padding: '4px 10px',
+                  flex: 'none',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {status.label}
+              </Text>
+            </UnstyledButton>
+          )
+        })}
+
+        <UnstyledButton
+          onClick={addItem}
+          px={11}
+          py={11}
+          ta="center"
+          style={{
+            border: '1.5px dashed rgba(23,21,15,.2)',
+            borderRadius: 10,
+          }}
+        >
+          <Text fz={13.5} fw={600} c="rgba(23,21,15,.5)">
+            + Добавить в очередь
+          </Text>
+        </UnstyledButton>
+      </Stack>
+    </Card>
+  )
+}

--- a/frontend/src/pages/feature-crossposting/ui/CrosspostingPage.tsx
+++ b/frontend/src/pages/feature-crossposting/ui/CrosspostingPage.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom'
 import {
   Anchor,
+  Badge,
   Box,
   Button,
   Card,
@@ -16,6 +17,7 @@ import { MarketingHeader } from '@/widgets/marketing-header'
 import { MarketingFooter } from '@/widgets/marketing-footer'
 import { useAuthModal } from '@/features/auth'
 import type { Icon } from '@tabler/icons-react'
+import { PostPreviewDemo } from './PostPreviewDemo'
 
 interface Capability {
   icon: Icon
@@ -53,9 +55,13 @@ export function CrosspostingPage() {
       <MarketingHeader active="features" />
 
       <Box component="main">
-        {/* Хлебные крошки */}
+        {/* Хлебные крошки: Главная / Возможности / Кросспостинг */}
         <Container size="lg" pt={{ base: 20, sm: 24 }}>
           <Text fz={13} c="dimmed">
+            <Anchor component={Link} to="/" c="dimmed" underline="never" inherit>
+              Главная
+            </Anchor>{' '}
+            /{' '}
             <Anchor component={Link} to="/#features" c="dimmed" underline="never" inherit>
               Возможности
             </Anchor>{' '}
@@ -66,62 +72,70 @@ export function CrosspostingPage() {
           </Text>
         </Container>
 
-        {/* Hero */}
+        {/* Hero: слева текстовый блок, справа демо-превью поста (на мобильном — друг под другом) */}
         <Box component="section" py={{ base: 40, sm: 56 }}>
           <Container size="lg">
-            <Stack gap={0} maw={640}>
-              <Box
-                style={{
-                  display: 'inline-block',
-                  alignSelf: 'flex-start',
-                  background: 'rgba(43,80,236,.08)',
-                  color: '#2B50EC',
-                  borderRadius: 'var(--mantine-radius-pill)',
-                  padding: '6px 12px',
-                  fontSize: 12,
-                  fontWeight: 700,
-                }}
-              >
-                Кросспостинг
-              </Box>
+            <SimpleGrid cols={{ base: 1, md: 2 }} spacing={48} verticalSpacing={40}>
+              <Stack gap={0} justify="center">
+                <Box>
+                  <Badge
+                    radius="xl"
+                    variant="light"
+                    color="brand"
+                    styles={{ root: { textTransform: 'none', fontWeight: 700 } }}
+                  >
+                    Кросспостинг
+                  </Badge>
+                </Box>
 
-              <Text
-                component="h1"
-                mt={16}
-                fz={{ base: 32, sm: 42 }}
-                fw={800}
-                lh={1.1}
-                style={{ letterSpacing: '-.7px' }}
-              >
-                Один пост —{' '}
                 <Text
-                  component="span"
-                  inherit
-                  style={{
-                    background: 'var(--mantine-color-accent-5)',
-                    padding: '0 8px',
-                    borderRadius: 8,
-                  }}
+                  component="h1"
+                  mt={16}
+                  fz={{ base: 32, sm: 42 }}
+                  fw={800}
+                  lh={1.1}
+                  style={{ letterSpacing: '-.7px' }}
                 >
-                  все площадки
-                </Text>{' '}
-                сразу
-              </Text>
+                  Один пост —{' '}
+                  <Text
+                    component="span"
+                    inherit
+                    style={{
+                      background: 'var(--mantine-color-accent-5)',
+                      padding: '0 8px',
+                      borderRadius: 8,
+                    }}
+                  >
+                    все площадки
+                  </Text>{' '}
+                  сразу
+                </Text>
 
-              <Text mt={16} fz={16} lh={1.55} c="rgba(23,21,15,.7)">
-                Напишите текст один раз. Отложка сама адаптирует его под каждую сеть: лимиты
-                символов, форматы, заголовки, кнопки и UTM-метки.
-              </Text>
+                <Text mt={16} fz={16} lh={1.55} c="rgba(23,21,15,.7)">
+                  Напишите текст один раз. Отложка сама адаптирует его под каждую сеть: лимиты
+                  символов, форматы, заголовки, кнопки и UTM-метки.
+                </Text>
 
-              <Group mt={24} gap={12}>
-                <Button size="md" radius="md" color="brand" onClick={() => open('register')}>
-                  Попробовать бесплатно
-                </Button>
-                <Button component={Link} to="/#features" size="md" radius="md" variant="default">
-                  Все возможности
-                </Button>
-              </Group>
-            </Stack>
+                <Group mt={24} gap={12}>
+                  <Button size="md" radius="md" color="brand" onClick={() => open('register')}>
+                    Попробовать бесплатно
+                  </Button>
+                  <Button
+                    component={Link}
+                    to="/features/autoposting"
+                    size="md"
+                    radius="md"
+                    variant="outline"
+                    color="dark"
+                  >
+                    А автопостинг?
+                  </Button>
+                </Group>
+              </Stack>
+
+              {/* Живое демо: превью поста под выбранную площадку */}
+              <PostPreviewDemo />
+            </SimpleGrid>
           </Container>
         </Box>
 

--- a/frontend/src/pages/feature-crossposting/ui/PostPreviewDemo.tsx
+++ b/frontend/src/pages/feature-crossposting/ui/PostPreviewDemo.tsx
@@ -1,0 +1,262 @@
+import { useState } from 'react'
+import { Box, Card, Group, Text, UnstyledButton } from '@mantine/core'
+import { NETWORKS } from '@/shared/config'
+
+const BORDER = 'rgba(23,21,15,.1)'
+const SOFT_BORDER = 'rgba(23,21,15,.09)'
+
+/** Общий текст поста кофейни «Молоко» — базу адаптируем под каждую сеть (как в макете). */
+const BASE_TEXT =
+  'Открыли запись на новогодние капучино-сеты! Бронируйте столик — вечером мест уже не будет.'
+
+interface NetworkPreview {
+  /** Строка под названием сообщества: формат публикации и время. */
+  meta: string
+  /** Заголовок над текстом — только у сетей со «статьями» (Дзен, RUTUBE). */
+  title?: string
+  text: string
+  /** Подпись заглушки медиа-блока. */
+  media: string
+  /** Кнопка внизу карточки — только там, где площадка её поддерживает (Telegram). */
+  btn?: string
+  /** Зелёные чипы-пометки: что «Отложка» адаптировала для этой сети. */
+  chips: string[]
+}
+
+// Мок-данные превью по 7 сетям, ключ — id из общего справочника NETWORKS.
+// Позже данные превью могут приходить с бэкенда — сейчас это осознанный мок,
+// реальная интеграция вне scope этой задачи.
+const PREVIEWS: Record<string, NetworkPreview> = {
+  vk: {
+    meta: 'пост сообщества · сегодня, 12:00',
+    text: `${BASE_TEXT}\n\n#кофейня #новыйгод #капучино`,
+    media: 'фото 1200 × 800',
+    chips: ['Хештеги подставлены', 'UTM-метка в ссылке'],
+  },
+  tg: {
+    meta: 'пост в канале · сегодня, 12:00',
+    text: BASE_TEXT,
+    media: 'фото 1280 × 720',
+    btn: 'Забронировать столик',
+    chips: ['Кнопка-ссылка добавлена', 'Уведомление подписчикам'],
+  },
+  ok: {
+    meta: 'заметка группы · сегодня, 12:00',
+    text: BASE_TEXT,
+    media: 'фото 1200 × 800',
+    chips: ['Формат «заметка с фото»', 'UTM-метка в ссылке'],
+  },
+  max: {
+    meta: 'сообщение в канал · сегодня, 12:00',
+    text: BASE_TEXT,
+    media: 'фото 1080 × 1080',
+    chips: ['Формат под мессенджер'],
+  },
+  dzen: {
+    meta: 'статья · сегодня, 12:05',
+    title: 'Новогодние капучино-сеты уже в меню',
+    text: `${BASE_TEXT} Рассказываем, что внутри сета и как забронировать.`,
+    media: 'обложка 1600 × 900',
+    chips: ['Добавлен заголовок для Дзена', 'Текст расширен до статьи'],
+  },
+  rutube: {
+    meta: 'видео · сегодня, 12:10',
+    title: 'Новогодние сеты: смотрим, что внутри',
+    text: `Описание к видео: ${BASE_TEXT}`,
+    media: 'видео 1920 × 1080 + обложка',
+    chips: ['Заголовок и описание к видео'],
+  },
+  youtube: {
+    meta: 'Shorts · сегодня, 12:10',
+    text: `Описание: ${BASE_TEXT}`,
+    media: 'вертикальное видео 1080 × 1920',
+    chips: ['Формат Shorts', 'Ссылка в описании'],
+  },
+}
+
+/**
+ * Демо «Как пост будет выглядеть на площадке» в hero страницы «Кросспостинг».
+ * Чистая клиентская симуляция на useState: переключение таба сети полностью
+ * перерисовывает превью поста под выбранную площадку. Текст поста рендерится
+ * как текст (React экранирует), без innerHTML — гайдлайн безопасности.
+ */
+export function PostPreviewDemo() {
+  const [activeIndex, setActiveIndex] = useState(0)
+
+  const network = NETWORKS[activeIndex]
+  const preview = PREVIEWS[network.id]
+
+  return (
+    <Card
+      withBorder
+      radius="lg"
+      p={0}
+      style={{
+        borderColor: BORDER,
+        background: '#fff',
+        boxShadow: '0 12px 32px rgba(23,21,15,.08)',
+        overflow: 'hidden',
+      }}
+    >
+      <Group
+        gap={12}
+        align="center"
+        px={18}
+        py={14}
+        wrap="wrap"
+        style={{ borderBottom: `1px solid ${SOFT_BORDER}` }}
+      >
+        <Text fz={15} fw={700}>
+          Как пост будет выглядеть на площадке
+        </Text>
+        <Text ml="auto" fz={12} c="rgba(23,21,15,.48)">
+          живое демо — переключайте
+        </Text>
+      </Group>
+
+      {/* Табы-пилюли по всем 7 сетям: активная заливается брендовым цветом сети */}
+      <Group gap={6} px={18} pt={14} pb={4} wrap="wrap">
+        {NETWORKS.map((net, index) => {
+          const active = index === activeIndex
+          return (
+            <UnstyledButton
+              key={net.id}
+              onClick={() => setActiveIndex(index)}
+              style={{
+                border: `1px solid ${active ? net.color : 'rgba(23,21,15,.15)'}`,
+                background: active ? net.color : '#fff',
+                color: active ? '#fff' : 'rgba(23,21,15,.75)',
+                borderRadius: 'var(--mantine-radius-pill)',
+                padding: '7px 13px',
+                fontSize: 12.5,
+                fontWeight: 600,
+              }}
+            >
+              {net.name}
+            </UnstyledButton>
+          )
+        })}
+      </Group>
+
+      <Box px={18} pt={14} pb={18}>
+        {/* Карточка превью поста кофейни «Молоко» под выбранную сеть */}
+        <Box
+          p={16}
+          style={{
+            background: '#F6F4EF',
+            border: '1px solid rgba(23,21,15,.08)',
+            borderRadius: 12,
+          }}
+        >
+          <Group gap={10} align="center" wrap="nowrap">
+            <Box
+              w={34}
+              h={34}
+              style={{
+                flex: 'none',
+                borderRadius: 'var(--mantine-radius-pill)',
+                background: 'var(--mantine-color-accent-5)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontWeight: 800,
+                fontSize: 14,
+              }}
+            >
+              М
+            </Box>
+            <Box>
+              <Text fz={13.5} fw={700}>
+                Кофейня «Молоко»
+              </Text>
+              <Text fz={11.5} c="rgba(23,21,15,.5)">
+                {preview.meta}
+              </Text>
+            </Box>
+            <Text
+              ml="auto"
+              fz={9.5}
+              fw={700}
+              c="#fff"
+              style={{
+                flex: 'none',
+                background: network.color,
+                borderRadius: 5,
+                padding: '3px 7px',
+              }}
+            >
+              {network.code}
+            </Text>
+          </Group>
+
+          {/* Заголовок — только у сетей, где он задан (Дзен, RUTUBE) */}
+          {preview.title && (
+            <Text mt={12} fz={15.5} fw={700}>
+              {preview.title}
+            </Text>
+          )}
+
+          {/* Текст поста рендерится как текст — без innerHTML (безопасность) */}
+          <Text mt={10} fz={14} lh={1.55} c="rgba(23,21,15,.85)" style={{ whiteSpace: 'pre-line' }}>
+            {preview.text}
+          </Text>
+
+          {/* Заглушка медиа: dashed-рамка с подписью, реальных файлов в демо нет */}
+          <Box
+            mt={12}
+            h={96}
+            style={{
+              border: '1.5px dashed rgba(23,21,15,.18)',
+              borderRadius: 10,
+              background: '#fff',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <Text fz={12} c="rgba(23,21,15,.4)">
+              {preview.media}
+            </Text>
+          </Box>
+
+          {/* Кнопка — только там, где площадка её поддерживает (Telegram) */}
+          {preview.btn && (
+            <Box
+              mt={12}
+              p={9}
+              ta="center"
+              style={{
+                border: `1.5px solid ${network.color}`,
+                color: network.color,
+                borderRadius: 9,
+                fontSize: 13.5,
+                fontWeight: 700,
+              }}
+            >
+              {preview.btn}
+            </Box>
+          )}
+        </Box>
+
+        {/* Зелёные чипы: что «Отложка» адаптировала под выбранную сеть */}
+        <Group gap={6} mt={12} wrap="wrap">
+          {preview.chips.map((chip) => (
+            <Text
+              key={chip}
+              fz={11.5}
+              fw={600}
+              style={{
+                color: '#1E7F4F',
+                background: 'rgba(34,160,107,.1)',
+                borderRadius: 'var(--mantine-radius-pill)',
+                padding: '5px 10px',
+              }}
+            >
+              ✓ {chip}
+            </Text>
+          ))}
+        </Group>
+      </Box>
+    </Card>
+  )
+}

--- a/frontend/src/pages/queue/ui/PostStatsModal.tsx
+++ b/frontend/src/pages/queue/ui/PostStatsModal.tsx
@@ -1,11 +1,37 @@
-import { Anchor, Group, Modal, Paper, SimpleGrid, Stack, Text } from '@mantine/core'
-import { IconExternalLink } from '@tabler/icons-react'
+import { useEffect, useState } from 'react'
+import { Anchor, Group, Modal, Paper, SimpleGrid, Skeleton, Stack, Text } from '@mantine/core'
 import { NETWORKS } from '@/shared/config'
 import { NetworkPill } from '@/shared/ui'
 import { formatDateTime } from '@/shared/lib'
-import type { Post } from '@/entities/scheduled-post'
+import type { Post, PostMetrics } from '@/entities/scheduled-post'
 
 const NETWORK_BY_ID = new Map(NETWORKS.map((n) => [n.id, n]))
+
+/** Кремовая подложка плиток и текста поста (макет app-dashboard, «Статистика поста»). */
+const PANEL_BG = '#F6F4EF'
+/** Акцент плитки ER: зелёная подложка и тёмно-зелёное число. */
+const ER_BG = 'rgba(34, 160, 107, 0.1)'
+const ER_COLOR = '#1E7F4F'
+
+/**
+ * Переходы и ER отправленных постов (#196). Поля clicks/er должны жить
+ * в PostMetrics — сущность entities/scheduled-post дорабатывается отдельно,
+ * поэтому до её обновления значения замоканы локально; одноимённые поля
+ * из сущности имеют приоритет, как только появятся (см. getExtendedMetrics).
+ */
+const EXTRA_METRICS: Record<string, { clicks: number; er: string }> = {
+  'sp-sent-1': { clicks: 342, er: '3.5%' },
+  'sp-sent-2': { clicks: 261, er: '5.8%' },
+  'sp-sent-3': { clicks: 148, er: '3.6%' },
+  'sp-sent-4': { clicks: 517, er: '5.6%' },
+}
+
+/** clicks/er: из сущности, если поля уже добавлены в PostMetrics; иначе — локальный мок. */
+function getExtendedMetrics(post: Post): { clicks?: number; er?: string } {
+  const entity = post.metrics as (PostMetrics & { clicks?: number; er?: string }) | undefined
+  const fallback = EXTRA_METRICS[post.id]
+  return { clicks: entity?.clicks ?? fallback?.clicks, er: entity?.er ?? fallback?.er }
+}
 
 interface PostStatsModalProps {
   post: Post | null
@@ -14,17 +40,19 @@ interface PostStatsModalProps {
 }
 
 interface MetricCellProps {
-  value: number
+  value: string
   label: string
+  /** Акцентная плитка (ER): зелёный фон и зелёное число. */
+  accent?: boolean
 }
 
-function MetricCell({ value, label }: MetricCellProps) {
+function MetricCell({ value, label, accent = false }: MetricCellProps) {
   return (
-    <Paper bg="gray.0" radius="md" p="sm">
-      <Text fz={19} fw={800}>
-        {value.toLocaleString('ru-RU')}
+    <Paper radius={11} p={12} style={{ background: accent ? ER_BG : PANEL_BG }}>
+      <Text fz={19} fw={800} style={accent ? { color: ER_COLOR } : undefined}>
+        {value}
       </Text>
-      <Text size="xs" c="dimmed" mt={2}>
+      <Text fz={11} mt={2} style={{ color: 'rgba(23, 21, 15, 0.5)' }}>
         {label}
       </Text>
     </Paper>
@@ -35,11 +63,31 @@ function MetricCell({ value, label }: MetricCellProps) {
 export function PostStatsModal({ post, opened, onClose }: PostStatsModalProps) {
   const network = post ? NETWORK_BY_ID.get(post.networkIds[0]) : undefined
   const metrics = post?.metrics
+  const extended = post ? getExtendedMetrics(post) : undefined
+
+  // Имитация загрузки статистики (~600 мс, как в остальных моках): реальный
+  // GET /posts/{id}/stats подключается отдельной backend-задачей (#147).
+  // Храним id поста, для которого «загрузка» завершилась; при закрытии сбрасываем,
+  // чтобы каждое открытие модалки снова показывало скелетоны.
+  const [loadedId, setLoadedId] = useState<string | null>(null)
+  const postId = post?.id
+  const isLoading = postId != null && loadedId !== postId
+
+  useEffect(() => {
+    if (!opened || postId == null) return undefined
+    const timer = window.setTimeout(() => setLoadedId(postId), 600)
+    return () => window.clearTimeout(timer)
+  }, [opened, postId])
+
+  const handleClose = () => {
+    setLoadedId(null)
+    onClose()
+  }
 
   return (
     <Modal
       opened={opened}
-      onClose={onClose}
+      onClose={handleClose}
       size="lg"
       radius="lg"
       title={
@@ -57,28 +105,44 @@ export function PostStatsModal({ post, opened, onClose }: PostStatsModalProps) {
             {network?.name} · опубликован {formatDateTime(post.scheduledAt)}
           </Text>
 
-          <Paper bg="gray.0" radius="md" p="md">
-            <Text size="sm" style={{ lineHeight: 1.55 }}>
+          <Paper radius={12} p={14} style={{ background: PANEL_BG }}>
+            <Text fz={13.5} style={{ lineHeight: 1.55, color: 'rgba(23, 21, 15, 0.8)' }}>
               {post.text}
             </Text>
           </Paper>
 
-          {metrics ? (
-            <SimpleGrid cols={{ base: 2, xs: 4 }} spacing="sm">
-              <MetricCell value={metrics.views} label="просмотры" />
-              <MetricCell value={metrics.likes} label="лайки" />
-              <MetricCell value={metrics.reposts} label="репосты" />
-              <MetricCell value={metrics.comments} label="комментарии" />
+          {isLoading ? (
+            <SimpleGrid cols={3} spacing={10}>
+              {Array.from({ length: 6 }, (_, index) => (
+                <Skeleton key={index} height={64} radius={11} />
+              ))}
             </SimpleGrid>
-          ) : null}
+          ) : metrics ? (
+            <SimpleGrid cols={3} spacing={10}>
+              <MetricCell value={metrics.views.toLocaleString('ru-RU')} label="просмотры" />
+              <MetricCell value={metrics.likes.toLocaleString('ru-RU')} label="лайки" />
+              <MetricCell value={metrics.reposts.toLocaleString('ru-RU')} label="репосты" />
+              <MetricCell value={metrics.comments.toLocaleString('ru-RU')} label="комментарии" />
+              <MetricCell
+                value={extended?.clicks != null ? extended.clicks.toLocaleString('ru-RU') : '—'}
+                label="переходы"
+              />
+              {/* ER выводим строкой как есть — на фронте не пересчитываем. */}
+              <MetricCell value={extended?.er ?? '—'} label="ER" accent />
+            </SimpleGrid>
+          ) : (
+            <Text size="sm" c="dimmed" ta="center" py="md">
+              Не удалось загрузить статистику
+            </Text>
+          )}
 
-          <Group justify="flex-end">
+          <Group justify="space-between" gap="sm">
+            <Text fz={12} style={{ color: 'rgba(23, 21, 15, 0.45)' }}>
+              UTM-метка: utm_source={post.networkIds[0]}
+            </Text>
             {/* TODO (Design First): реальная ссылка из GET /posts/{id} (поле publishedUrl). */}
-            <Anchor href="#" fw={700} c="brand" onClick={(e) => e.preventDefault()}>
-              <Group gap={4} wrap="nowrap">
-                Открыть на площадке
-                <IconExternalLink size={16} />
-              </Group>
+            <Anchor href="#" fz={13} fw={700} c="brand" onClick={(event) => event.preventDefault()}>
+              Открыть на площадке →
             </Anchor>
           </Group>
         </Stack>


### PR DESCRIPTION
Closes #196

Стек: после PR #194-queue-polish.

- 6 плиток (просмотры, лайки, репосты, комментарии, переходы, ER) в SimpleGrid 3; ER — акцент в success-тонах
- Подвал: «UTM-метка: utm_source=<сеть>» + «Открыть на площадке →»
- 6 скелетонов при каждом открытии (мок 600мс), ошибка при отсутствии метрик
- clicks/er пока в локальном моке с приоритетом полей сущности (getExtendedMetrics) — при добавлении полей в PostMetrics код подхватит их без правок; у постов без данных — «—»

Проверено: 6 метрик и UTM в живой модалке. lint/tsc/build чисто.