### PR TITLE
feat(frontend): «Кросспостинг» — демо-превью поста по 7 площадкам

### DIFF
--- a/frontend/src/pages/feature-crossposting/ui/CrosspostingPage.tsx
+++ b/frontend/src/pages/feature-crossposting/ui/CrosspostingPage.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom'
 import {
   Anchor,
+  Badge,
   Box,
   Button,
   Card,
@@ -16,6 +17,7 @@ import { MarketingHeader } from '@/widgets/marketing-header'
 import { MarketingFooter } from '@/widgets/marketing-footer'
 import { useAuthModal } from '@/features/auth'
 import type { Icon } from '@tabler/icons-react'
+import { PostPreviewDemo } from './PostPreviewDemo'
 
 interface Capability {
   icon: Icon
@@ -53,9 +55,13 @@ export function CrosspostingPage() {
       <MarketingHeader active="features" />
 
       <Box component="main">
-        {/* Хлебные крошки */}
+        {/* Хлебные крошки: Главная / Возможности / Кросспостинг */}
         <Container size="lg" pt={{ base: 20, sm: 24 }}>
           <Text fz={13} c="dimmed">
+            <Anchor component={Link} to="/" c="dimmed" underline="never" inherit>
+              Главная
+            </Anchor>{' '}
+            /{' '}
             <Anchor component={Link} to="/#features" c="dimmed" underline="never" inherit>
               Возможности
             </Anchor>{' '}
@@ -66,62 +72,70 @@ export function CrosspostingPage() {
           </Text>
         </Container>
 
-        {/* Hero */}
+        {/* Hero: слева текстовый блок, справа демо-превью поста (на мобильном — друг под другом) */}
         <Box component="section" py={{ base: 40, sm: 56 }}>
           <Container size="lg">
-            <Stack gap={0} maw={640}>
-              <Box
-                style={{
-                  display: 'inline-block',
-                  alignSelf: 'flex-start',
-                  background: 'rgba(43,80,236,.08)',
-                  color: '#2B50EC',
-                  borderRadius: 'var(--mantine-radius-pill)',
-                  padding: '6px 12px',
-                  fontSize: 12,
-                  fontWeight: 700,
-                }}
-              >
-                Кросспостинг
-              </Box>
+            <SimpleGrid cols={{ base: 1, md: 2 }} spacing={48} verticalSpacing={40}>
+              <Stack gap={0} justify="center">
+                <Box>
+                  <Badge
+                    radius="xl"
+                    variant="light"
+                    color="brand"
+                    styles={{ root: { textTransform: 'none', fontWeight: 700 } }}
+                  >
+                    Кросспостинг
+                  </Badge>
+                </Box>
 
-              <Text
-                component="h1"
-                mt={16}
-                fz={{ base: 32, sm: 42 }}
-                fw={800}
-                lh={1.1}
-                style={{ letterSpacing: '-.7px' }}
-              >
-                Один пост —{' '}
                 <Text
-                  component="span"
-                  inherit
-                  style={{
-                    background: 'var(--mantine-color-accent-5)',
-                    padding: '0 8px',
-                    borderRadius: 8,
-                  }}
+                  component="h1"
+                  mt={16}
+                  fz={{ base: 32, sm: 42 }}
+                  fw={800}
+                  lh={1.1}
+                  style={{ letterSpacing: '-.7px' }}
                 >
-                  все площадки
-                </Text>{' '}
-                сразу
-              </Text>
+                  Один пост —{' '}
+                  <Text
+                    component="span"
+                    inherit
+                    style={{
+                      background: 'var(--mantine-color-accent-5)',
+                      padding: '0 8px',
+                      borderRadius: 8,
+                    }}
+                  >
+                    все площадки
+                  </Text>{' '}
+                  сразу
+                </Text>
 
-              <Text mt={16} fz={16} lh={1.55} c="rgba(23,21,15,.7)">
-                Напишите текст один раз. Отложка сама адаптирует его под каждую сеть: лимиты
-                символов, форматы, заголовки, кнопки и UTM-метки.
-              </Text>
+                <Text mt={16} fz={16} lh={1.55} c="rgba(23,21,15,.7)">
+                  Напишите текст один раз. Отложка сама адаптирует его под каждую сеть: лимиты
+                  символов, форматы, заголовки, кнопки и UTM-метки.
+                </Text>
 
-              <Group mt={24} gap={12}>
-                <Button size="md" radius="md" color="brand" onClick={() => open('register')}>
-                  Попробовать бесплатно
-                </Button>
-                <Button component={Link} to="/#features" size="md" radius="md" variant="default">
-                  Все возможности
-                </Button>
-              </Group>
-            </Stack>
+                <Group mt={24} gap={12}>
+                  <Button size="md" radius="md" color="brand" onClick={() => open('register')}>
+                    Попробовать бесплатно
+                  </Button>
+                  <Button
+                    component={Link}
+                    to="/features/autoposting"
+                    size="md"
+                    radius="md"
+                    variant="outline"
+                    color="dark"
+                  >
+                    А автопостинг?
+                  </Button>
+                </Group>
+              </Stack>
+
+              {/* Живое демо: превью поста под выбранную площадку */}
+              <PostPreviewDemo />
+            </SimpleGrid>
           </Container>
         </Box>
 

--- a/frontend/src/pages/feature-crossposting/ui/PostPreviewDemo.tsx
+++ b/frontend/src/pages/feature-crossposting/ui/PostPreviewDemo.tsx
@@ -1,0 +1,262 @@
+import { useState } from 'react'
+import { Box, Card, Group, Text, UnstyledButton } from '@mantine/core'
+import { NETWORKS } from '@/shared/config'
+
+const BORDER = 'rgba(23,21,15,.1)'
+const SOFT_BORDER = 'rgba(23,21,15,.09)'
+
+/** Общий текст поста кофейни «Молоко» — базу адаптируем под каждую сеть (как в макете). */
+const BASE_TEXT =
+  'Открыли запись на новогодние капучино-сеты! Бронируйте столик — вечером мест уже не будет.'
+
+interface NetworkPreview {
+  /** Строка под названием сообщества: формат публикации и время. */
+  meta: string
+  /** Заголовок над текстом — только у сетей со «статьями» (Дзен, RUTUBE). */
+  title?: string
+  text: string
+  /** Подпись заглушки медиа-блока. */
+  media: string
+  /** Кнопка внизу карточки — только там, где площадка её поддерживает (Telegram). */
+  btn?: string
+  /** Зелёные чипы-пометки: что «Отложка» адаптировала для этой сети. */
+  chips: string[]
+}
+
+// Мок-данные превью по 7 сетям, ключ — id из общего справочника NETWORKS.
+// Позже данные превью могут приходить с бэкенда — сейчас это осознанный мок,
+// реальная интеграция вне scope этой задачи.
+const PREVIEWS: Record<string, NetworkPreview> = {
+  vk: {
+    meta: 'пост сообщества · сегодня, 12:00',
+    text: `${BASE_TEXT}\n\n#кофейня #новыйгод #капучино`,
+    media: 'фото 1200 × 800',
+    chips: ['Хештеги подставлены', 'UTM-метка в ссылке'],
+  },
+  tg: {
+    meta: 'пост в канале · сегодня, 12:00',
+    text: BASE_TEXT,
+    media: 'фото 1280 × 720',
+    btn: 'Забронировать столик',
+    chips: ['Кнопка-ссылка добавлена', 'Уведомление подписчикам'],
+  },
+  ok: {
+    meta: 'заметка группы · сегодня, 12:00',
+    text: BASE_TEXT,
+    media: 'фото 1200 × 800',
+    chips: ['Формат «заметка с фото»', 'UTM-метка в ссылке'],
+  },
+  max: {
+    meta: 'сообщение в канал · сегодня, 12:00',
+    text: BASE_TEXT,
+    media: 'фото 1080 × 1080',
+    chips: ['Формат под мессенджер'],
+  },
+  dzen: {
+    meta: 'статья · сегодня, 12:05',
+    title: 'Новогодние капучино-сеты уже в меню',
+    text: `${BASE_TEXT} Рассказываем, что внутри сета и как забронировать.`,
+    media: 'обложка 1600 × 900',
+    chips: ['Добавлен заголовок для Дзена', 'Текст расширен до статьи'],
+  },
+  rutube: {
+    meta: 'видео · сегодня, 12:10',
+    title: 'Новогодние сеты: смотрим, что внутри',
+    text: `Описание к видео: ${BASE_TEXT}`,
+    media: 'видео 1920 × 1080 + обложка',
+    chips: ['Заголовок и описание к видео'],
+  },
+  youtube: {
+    meta: 'Shorts · сегодня, 12:10',
+    text: `Описание: ${BASE_TEXT}`,
+    media: 'вертикальное видео 1080 × 1920',
+    chips: ['Формат Shorts', 'Ссылка в описании'],
+  },
+}
+
+/**
+ * Демо «Как пост будет выглядеть на площадке» в hero страницы «Кросспостинг».
+ * Чистая клиентская симуляция на useState: переключение таба сети полностью
+ * перерисовывает превью поста под выбранную площадку. Текст поста рендерится
+ * как текст (React экранирует), без innerHTML — гайдлайн безопасности.
+ */
+export function PostPreviewDemo() {
+  const [activeIndex, setActiveIndex] = useState(0)
+
+  const network = NETWORKS[activeIndex]
+  const preview = PREVIEWS[network.id]
+
+  return (
+    <Card
+      withBorder
+      radius="lg"
+      p={0}
+      style={{
+        borderColor: BORDER,
+        background: '#fff',
+        boxShadow: '0 12px 32px rgba(23,21,15,.08)',
+        overflow: 'hidden',
+      }}
+    >
+      <Group
+        gap={12}
+        align="center"
+        px={18}
+        py={14}
+        wrap="wrap"
+        style={{ borderBottom: `1px solid ${SOFT_BORDER}` }}
+      >
+        <Text fz={15} fw={700}>
+          Как пост будет выглядеть на площадке
+        </Text>
+        <Text ml="auto" fz={12} c="rgba(23,21,15,.48)">
+          живое демо — переключайте
+        </Text>
+      </Group>
+
+      {/* Табы-пилюли по всем 7 сетям: активная заливается брендовым цветом сети */}
+      <Group gap={6} px={18} pt={14} pb={4} wrap="wrap">
+        {NETWORKS.map((net, index) => {
+          const active = index === activeIndex
+          return (
+            <UnstyledButton
+              key={net.id}
+              onClick={() => setActiveIndex(index)}
+              style={{
+                border: `1px solid ${active ? net.color : 'rgba(23,21,15,.15)'}`,
+                background: active ? net.color : '#fff',
+                color: active ? '#fff' : 'rgba(23,21,15,.75)',
+                borderRadius: 'var(--mantine-radius-pill)',
+                padding: '7px 13px',
+                fontSize: 12.5,
+                fontWeight: 600,
+              }}
+            >
+              {net.name}
+            </UnstyledButton>
+          )
+        })}
+      </Group>
+
+      <Box px={18} pt={14} pb={18}>
+        {/* Карточка превью поста кофейни «Молоко» под выбранную сеть */}
+        <Box
+          p={16}
+          style={{
+            background: '#F6F4EF',
+            border: '1px solid rgba(23,21,15,.08)',
+            borderRadius: 12,
+          }}
+        >
+          <Group gap={10} align="center" wrap="nowrap">
+            <Box
+              w={34}
+              h={34}
+              style={{
+                flex: 'none',
+                borderRadius: 'var(--mantine-radius-pill)',
+                background: 'var(--mantine-color-accent-5)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontWeight: 800,
+                fontSize: 14,
+              }}
+            >
+              М
+            </Box>
+            <Box>
+              <Text fz={13.5} fw={700}>
+                Кофейня «Молоко»
+              </Text>
+              <Text fz={11.5} c="rgba(23,21,15,.5)">
+                {preview.meta}
+              </Text>
+            </Box>
+            <Text
+              ml="auto"
+              fz={9.5}
+              fw={700}
+              c="#fff"
+              style={{
+                flex: 'none',
+                background: network.color,
+                borderRadius: 5,
+                padding: '3px 7px',
+              }}
+            >
+              {network.code}
+            </Text>
+          </Group>
+
+          {/* Заголовок — только у сетей, где он задан (Дзен, RUTUBE) */}
+          {preview.title && (
+            <Text mt={12} fz={15.5} fw={700}>
+              {preview.title}
+            </Text>
+          )}
+
+          {/* Текст поста рендерится как текст — без innerHTML (безопасность) */}
+          <Text mt={10} fz={14} lh={1.55} c="rgba(23,21,15,.85)" style={{ whiteSpace: 'pre-line' }}>
+            {preview.text}
+          </Text>
+
+          {/* Заглушка медиа: dashed-рамка с подписью, реальных файлов в демо нет */}
+          <Box
+            mt={12}
+            h={96}
+            style={{
+              border: '1.5px dashed rgba(23,21,15,.18)',
+              borderRadius: 10,
+              background: '#fff',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <Text fz={12} c="rgba(23,21,15,.4)">
+              {preview.media}
+            </Text>
+          </Box>
+
+          {/* Кнопка — только там, где площадка её поддерживает (Telegram) */}
+          {preview.btn && (
+            <Box
+              mt={12}
+              p={9}
+              ta="center"
+              style={{
+                border: `1.5px solid ${network.color}`,
+                color: network.color,
+                borderRadius: 9,
+                fontSize: 13.5,
+                fontWeight: 700,
+              }}
+            >
+              {preview.btn}
+            </Box>
+          )}
+        </Box>
+
+        {/* Зелёные чипы: что «Отложка» адаптировала под выбранную сеть */}
+        <Group gap={6} mt={12} wrap="wrap">
+          {preview.chips.map((chip) => (
+            <Text
+              key={chip}
+              fz={11.5}
+              fw={600}
+              style={{
+                color: '#1E7F4F',
+                background: 'rgba(34,160,107,.1)',
+                borderRadius: 'var(--mantine-radius-pill)',
+                padding: '5px 10px',
+              }}
+            >
+              ✓ {chip}
+            </Text>
+          ))}
+        </Group>
+      </Box>
+    </Card>
+  )
+}


### PR DESCRIPTION
Closes #183

Стек: после PR #182-autoposting-page.

- Hero в 2 колонки, справа PostPreviewDemo: 7 табов-пилюль из NETWORKS, превью кофейни «Молоко» меняет meta/текст/чипы; условные элементы (заголовок у Дзен/RUTUBE, кнопка «Забронировать столик» у Telegram в брендовом цвете)
- Текст рендерится как текст (white-space: pre-line), НИКАКОГО innerHTML — гайдлайн безопасности соблюдён
- Кнопка «А автопостинг?», крошки с «Главной», пилюля hero на brand-токене

Проверено агентом вживую: переключение 7 табов, условные элементы. lint/tsc/build чисто.