### PR TITLE
feat(frontend): OAuth — мок-callback, ошибка в модалке входа, hover кнопок

### DIFF
--- a/frontend/src/app/routes/AppRouter.tsx
+++ b/frontend/src/app/routes/AppRouter.tsx
@@ -9,6 +9,7 @@ import { ReportsPage } from '@/pages/reports'
 import { TeamPage } from '@/pages/team'
 import { SettingsPage } from '@/pages/settings'
 import { LoginPage } from '@/pages/login'
+import { AuthCallbackPage } from '@/pages/auth-callback'
 import { LegalPage } from '@/pages/legal'
 import { PricingPage } from '@/pages/pricing'
 import { NotFoundPage } from '@/pages/not-found'
@@ -34,6 +35,8 @@ const router = createBrowserRouter([
       // Публичный маркетинг-сайт
       { path: '/', element: <LandingPage /> },
       { path: '/login', element: <LoginPage /> },
+      // Возврат с OAuth-провайдера: разбор query, мок-сохранение сессии, редирект
+      { path: '/auth/callback', element: <AuthCallbackPage /> },
       { path: '/pricing', element: <PricingPage /> },
       { path: '/features/autoposting', element: <AutopostingPage /> },
       { path: '/features/crossposting', element: <CrosspostingPage /> },

--- a/frontend/src/features/auth/api/mockAuthApi.ts
+++ b/frontend/src/features/auth/api/mockAuthApi.ts
@@ -57,6 +57,14 @@ export async function mockRequestPasswordReset(email: string): Promise<void> {
   }
 }
 
+/**
+ * Мок обмена OAuth-кода на сессию (возврат провайдера на /auth/callback).
+ * Реальные проверка code/state и httpOnly-кука — backend-задачи (#111, #147).
+ */
+export async function mockExchangeOauthCode(): Promise<void> {
+  await wait()
+}
+
 /** Достаём текст ошибки из мок-запроса (на будущее — из ответа API) */
 export function getAuthErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : 'Что-то пошло не так. Попробуйте ещё раз.'

--- a/frontend/src/features/auth/index.ts
+++ b/frontend/src/features/auth/index.ts
@@ -4,7 +4,11 @@ export {
   openAuth,
   closeAuth,
   setAuthMode,
+  setOauthError,
   selectAuthModal,
 } from './model/authModalSlice'
 export type { AuthMode, AuthModalState } from './model/authModalSlice'
 export { useAuthModal } from './model/hooks'
+export { OAUTH_PROVIDERS } from './model/oauthProviders'
+export type { OAuthProvider } from './model/oauthProviders'
+export { mockExchangeOauthCode } from './api/mockAuthApi'

--- a/frontend/src/features/auth/model/authModalSlice.ts
+++ b/frontend/src/features/auth/model/authModalSlice.ts
@@ -8,28 +8,38 @@ export type AuthMode = 'login' | 'register' | 'reset'
 export interface AuthModalState {
   opened: boolean
   mode: AuthMode
+  /** Текст ошибки OAuth-входа (возврат с /auth/callback?error=…) — Alert над кнопками сервисов */
+  oauthError: string | null
 }
 
-const initialState: AuthModalState = { opened: false, mode: 'login' }
+const initialState: AuthModalState = { opened: false, mode: 'login', oauthError: null }
 
 export const authModalSlice = createSlice({
   name: 'authModal',
   initialState,
   reducers: {
+    // Не сбрасывает oauthError: страница callback ставит текст ошибки ДО того,
+    // как /login откроет модалку, — иначе Alert исчезал бы сразу.
     openAuth(state, action: PayloadAction<AuthMode | undefined>) {
       state.opened = true
       state.mode = action.payload ?? 'login'
     },
     closeAuth(state) {
       state.opened = false
+      state.oauthError = null
     },
     setAuthMode(state, action: PayloadAction<AuthMode>) {
       state.mode = action.payload
+      // Смена вкладки (вход/регистрация/сброс) убирает устаревшую ошибку OAuth
+      state.oauthError = null
+    },
+    setOauthError(state, action: PayloadAction<string | null>) {
+      state.oauthError = action.payload
     },
   },
 })
 
-export const { openAuth, closeAuth, setAuthMode } = authModalSlice.actions
+export const { openAuth, closeAuth, setAuthMode, setOauthError } = authModalSlice.actions
 
 export const selectAuthModal = (state: { authModal: AuthModalState }): AuthModalState =>
   state.authModal

--- a/frontend/src/features/auth/model/hooks.ts
+++ b/frontend/src/features/auth/model/hooks.ts
@@ -1,16 +1,18 @@
 import { useDispatch, useSelector } from 'react-redux'
-import { closeAuth, openAuth, selectAuthModal, setAuthMode } from './authModalSlice'
+import { closeAuth, openAuth, selectAuthModal, setAuthMode, setOauthError } from './authModalSlice'
 import type { AuthMode } from './authModalSlice'
 
 /** Управление auth-модалкой: открыть в нужном режиме / закрыть / сменить режим. */
 export function useAuthModal() {
   const dispatch = useDispatch()
-  const { opened, mode } = useSelector(selectAuthModal)
+  const { opened, mode, oauthError } = useSelector(selectAuthModal)
   return {
     opened,
     mode,
+    oauthError,
     open: (m?: AuthMode) => dispatch(openAuth(m)),
     close: () => dispatch(closeAuth()),
     setMode: (m: AuthMode) => dispatch(setAuthMode(m)),
+    clearOauthError: () => dispatch(setOauthError(null)),
   }
 }

--- a/frontend/src/features/auth/model/oauthProviders.ts
+++ b/frontend/src/features/auth/model/oauthProviders.ts
@@ -1,0 +1,24 @@
+/**
+ * 6 провайдеров быстрого входа из макета (docs/design/mockups/login.html):
+ * порядок, подписи и бренд-цвета фиксированы макетом. Цвета — брендовые
+ * палитры внешних сервисов, а не токены темы, поэтому заданы литералами.
+ */
+export interface OAuthProvider {
+  id: string
+  label: string
+  /** Брендовый цвет фона кнопки */
+  color: string
+  /** Цвет текста поверх брендового фона */
+  fg: string
+  /** Сила hover-затемнения: жёлтой T-ID хватает 0.95, остальным — 0.92 */
+  hoverBrightness: number
+}
+
+export const OAUTH_PROVIDERS: OAuthProvider[] = [
+  { id: 'vk', label: 'VK ID', color: '#0077FF', fg: '#fff', hoverBrightness: 0.92 },
+  { id: 'telegram', label: 'Telegram', color: '#27A6E5', fg: '#fff', hoverBrightness: 0.92 },
+  { id: 'yandex', label: 'Яндекс', color: '#FC3F1D', fg: '#fff', hoverBrightness: 0.92 },
+  { id: 'sber', label: 'Сбер ID', color: '#21A038', fg: '#fff', hoverBrightness: 0.92 },
+  { id: 'tinkoff', label: 'T-ID', color: '#FFDD2D', fg: '#17150F', hoverBrightness: 0.95 },
+  { id: 'gosuslugi', label: 'Госуслуги', color: '#0D4CD3', fg: '#fff', hoverBrightness: 0.92 },
+]

--- a/frontend/src/features/auth/ui/AuthModal.tsx
+++ b/frontend/src/features/auth/ui/AuthModal.tsx
@@ -1,4 +1,5 @@
-import { Anchor, Divider, Modal, SegmentedControl, Stack, Text, Title } from '@mantine/core'
+import { Alert, Anchor, Divider, Modal, SegmentedControl, Stack, Text, Title } from '@mantine/core'
+import { IconAlertCircle } from '@tabler/icons-react'
 import { useAuthModal } from '../model/hooks'
 import type { AuthMode } from '../model/authModalSlice'
 import { OAuthButtons } from './OAuthButtons'
@@ -26,7 +27,7 @@ const COPY: Record<AuthMode, { title: string; subtitle: string }> = {
  * (как в макете docs/design/mockups/login.html). Открывается через Redux (useAuthModal).
  */
 export function AuthModal() {
-  const { opened, mode, close, setMode } = useAuthModal()
+  const { opened, mode, close, setMode, oauthError, clearOauthError } = useAuthModal()
   const isAuth = mode !== 'reset'
 
   return (
@@ -66,6 +67,17 @@ export function AuthModal() {
 
         {isAuth && (
           <>
+            {/* Ошибка возврата с OAuth-callback (?error=…) — над блоком быстрого входа */}
+            {oauthError && (
+              <Alert
+                color="red"
+                icon={<IconAlertCircle size={18} />}
+                withCloseButton
+                onClose={clearOauthError}
+              >
+                {oauthError}
+              </Alert>
+            )}
             <OAuthButtons />
             <Divider label="или по почте" labelPosition="center" />
           </>

--- a/frontend/src/features/auth/ui/OAuthButtons.module.css
+++ b/frontend/src/features/auth/ui/OAuthButtons.module.css
@@ -1,0 +1,9 @@
+/* Лёгкое затемнение бренд-кнопки при наведении (login.html: brightness .92, T-ID — .95).
+   Сила затемнения приходит CSS-переменной из объекта провайдера. */
+.provider {
+  transition: filter 120ms ease;
+}
+
+.provider:hover {
+  filter: brightness(var(--oauth-hover-brightness, 0.92));
+}

--- a/frontend/src/features/auth/ui/OAuthButtons.tsx
+++ b/frontend/src/features/auth/ui/OAuthButtons.tsx
@@ -1,29 +1,30 @@
+import type { CSSProperties } from 'react'
 import { Button, SimpleGrid } from '@mantine/core'
-import { env } from '@/shared/config'
+import { OAUTH_PROVIDERS } from '../model/oauthProviders'
+import classes from './OAuthButtons.module.css'
 
-/** 6 провайдеров OAuth из макета входа, с брендовыми цветами. */
-const PROVIDERS = [
-  { id: 'vk', label: 'VK ID', color: '#0077FF', fg: '#fff' },
-  { id: 'telegram', label: 'Telegram', color: '#27A6E5', fg: '#fff' },
-  { id: 'yandex', label: 'Яндекс', color: '#FC3F1D', fg: '#fff' },
-  { id: 'sber', label: 'Сбер ID', color: '#21A038', fg: '#fff' },
-  { id: 'tinkoff', label: 'T-ID', color: '#FFDD2D', fg: '#17150F' },
-  { id: 'gosuslugi', label: 'Госуслуги', color: '#0D4CD3', fg: '#fff' },
-]
-
+/** Сетка 3×2 кнопок быстрого входа через сервисы (макет login.html). */
 export function OAuthButtons() {
   return (
-    <SimpleGrid cols={3} spacing={6}>
-      {PROVIDERS.map((p) => (
+    <SimpleGrid cols={3} spacing={8}>
+      {OAUTH_PROVIDERS.map((p) => (
         <Button
           key={p.id}
           size="xs"
-          radius="md"
+          radius={10}
           fw={600}
+          className={classes.provider}
           styles={{ root: { background: p.color, color: p.fg } }}
+          // Сила hover-затемнения — CSS-переменной (см. OAuthButtons.module.css)
+          style={{ '--oauth-hover-brightness': String(p.hoverBrightness) } as CSSProperties}
           onClick={() => {
-            // Design First: реальный OAuth-редирект на бэкенд (/auth/{provider}), см. issue #133/#111.
-            window.location.href = `${env.apiUrl}/auth/${p.id}`
+            // TODO(#111): реальный OAuth — полный редирект на бэкенд:
+            // window.location.assign(`${env.apiUrl}/auth/${p.id}/authorize`).
+            // Бэкенда пока нет, поэтому мок: «провайдер» мгновенно возвращает
+            // пользователя на наш callback с кодом (обработка — pages/auth-callback).
+            window.location.assign(
+              `/auth/callback?provider=${p.id}&code=mock-code&state=mock-state`,
+            )
           }}
         >
           {p.label}

--- a/frontend/src/pages/auth-callback/index.ts
+++ b/frontend/src/pages/auth-callback/index.ts
@@ -1,0 +1,1 @@
+export { AuthCallbackPage } from './ui/AuthCallbackPage'

--- a/frontend/src/pages/auth-callback/ui/AuthCallbackPage.tsx
+++ b/frontend/src/pages/auth-callback/ui/AuthCallbackPage.tsx
@@ -1,0 +1,58 @@
+import { useEffect } from 'react'
+import { Center, Loader, Stack, Text } from '@mantine/core'
+import { useDispatch } from 'react-redux'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { login } from '@/entities/session'
+import { mockExchangeOauthCode, OAUTH_PROVIDERS, setOauthError } from '@/features/auth'
+
+/** Дефолтный текст ошибки, когда провайдер не прислал error_description */
+const DEFAULT_OAUTH_ERROR = 'Не удалось войти через сервис, попробуйте ещё раз.'
+
+/**
+ * /auth/callback — лёгкий обработчик возврата с OAuth-провайдера.
+ * Разбирает query (provider, code, state, error, error_description):
+ * успех — мок-обмен кода на сессию и редирект в кабинет; ошибка — возврат
+ * на /login с открытием auth-модалки и Alert с текстом ошибки.
+ */
+export function AuthCallbackPage() {
+  const [params] = useSearchParams()
+  const dispatch = useDispatch()
+  const navigate = useNavigate()
+
+  // Название сервиса для текста лоадера («Входим через VK ID…»)
+  const provider = params.get('provider')
+  const providerLabel = OAUTH_PROVIDERS.find((p) => p.id === provider)?.label
+
+  useEffect(() => {
+    // Провайдер вернул ошибку (отказ пользователя, сбой и т.п.) — в кабинет
+    // не пускаем: текст покажет Alert в модалке входа, которую откроет /login
+    if (params.get('error') !== null) {
+      dispatch(setOauthError(params.get('error_description') || DEFAULT_OAUTH_ERROR))
+      navigate('/login', { replace: true })
+      return
+    }
+
+    // Успех: «меняем» code на сессию мок-запросом и уводим в кабинет.
+    // Реальные проверка code/state и httpOnly-кука — backend (#111, #147).
+    let cancelled = false
+    void mockExchangeOauthCode().then(() => {
+      if (cancelled) return
+      dispatch(login())
+      navigate('/app/calendar', { replace: true })
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [dispatch, navigate, params])
+
+  return (
+    <Center mih="100dvh">
+      <Stack align="center" gap="sm">
+        <Loader />
+        <Text c="dimmed" fz="sm">
+          {providerLabel ? `Входим через ${providerLabel}…` : 'Завершаем вход…'}
+        </Text>
+      </Stack>
+    </Center>
+  )
+}


### PR DESCRIPTION
Closes #188

Стек: после PR #186-legal-page. /login — модалка (решение заказчика, см. #187).

- Маршрут /auth/callback (pages/auth-callback): парсит provider/code/error; успех — мок-обмен (600мс, Loader «Входим через …») → login() → /app/calendar; ошибка — setOauthError + редирект на /login, Alert в модалке над OAuth-блоком
- OAuthButtons: hover-затемнение (CSS-модуль), radius/spacing по макету; клик — мок-редирект на /auth/callback с TODO(#111) на реальный /auth/{provider}/authorize
- authModalSlice: oauthError (сбрасывается при closeAuth/смене вкладки)

Проверено в интеграционном смоуке: успешный callback приводит в кабинет, ?error= оставляет вне /app и показывает Alert. lint/tsc/build чисто.