### PR TITLE
feat(frontend): квота постов — данные, PlanWidget, баннеры и мягкий enforcement

### DIFF
--- a/frontend/src/entities/subscription/api/subscriptionApi.ts
+++ b/frontend/src/entities/subscription/api/subscriptionApi.ts
@@ -43,3 +43,20 @@ export function setUsage(queryClient: QueryClient, patch: Partial<Subscription['
     usage: { ...old.usage, ...patch },
   }))
 }
+
+/**
+ * Демо-мутатор: применить новый тариф после «оплаты» в модалке апгрейда —
+ * название, лимиты (Infinity = безлимит) и дату продления; расход периода сохраняем,
+ * чтобы счётчики «N из M» не обнулялись при смене тарифа.
+ */
+export function applyPlan(
+  queryClient: QueryClient,
+  patch: { plan: string; limits: Subscription['limits']; renewsAt?: string },
+) {
+  queryClient.setQueryData<Subscription>(subscriptionKeys.all, (old = SEED) => ({
+    ...old,
+    plan: patch.plan,
+    limits: patch.limits,
+    renewsAt: patch.renewsAt ?? old.renewsAt,
+  }))
+}

--- a/frontend/src/entities/subscription/index.ts
+++ b/frontend/src/entities/subscription/index.ts
@@ -3,6 +3,7 @@ export {
   subscriptionKeys,
   incrementAiUsage,
   setUsage,
+  applyPlan,
 } from './api/subscriptionApi'
 export { useQuota } from './model/useQuota'
 export type { QuotaState } from './model/useQuota'

--- a/frontend/src/entities/subscription/model/useQuota.ts
+++ b/frontend/src/entities/subscription/model/useQuota.ts
@@ -4,14 +4,29 @@ import { useSubscription } from '../api/subscriptionApi'
 export interface QuotaState {
   used: number
   limit: number
+  /** Безлимитный ресурс (limit = Infinity): счётчики и пороги не считаются. */
+  unlimited: boolean
+  /** Доля израсходованного, 0–100 — для прогресс-баров; 0 при безлимите. */
+  percent: number
+  /** Приближение к лимиту: израсходовано ≥ 80%, но лимит ещё не достигнут. */
+  warning: boolean
   exhausted: boolean
 }
 
-/** Квота по виду ресурса: ИИ-генерации ('ai') или запланированные посты ('posts'). */
+/**
+ * Квота по виду ресурса: ИИ-генерации ('ai') или запланированные посты ('posts').
+ * Все пороги (предупреждение, исчерпание) считаются здесь, чтобы компоненты
+ * (PlanWidget, композер, баннеры) опирались только на данные хука.
+ */
 export function useQuota(kind: 'ai' | 'posts'): QuotaState {
   const { data } = useSubscription()
   const used = kind === 'ai' ? data.usage.aiRequests : data.usage.scheduledPosts
   const limit = kind === 'ai' ? data.limits.aiRequests : data.limits.scheduledPosts
   // Безлимит (Infinity) исчерпать нельзя
-  return { used, limit, exhausted: Number.isFinite(limit) && used >= limit }
+  const unlimited = !Number.isFinite(limit)
+  const percent = unlimited ? 0 : Math.min(100, Math.round((used / limit) * 100))
+  const exhausted = !unlimited && used >= limit
+  // Порог «скоро лимит» — с 80% расхода, в цветах виджета это orange
+  const warning = !unlimited && !exhausted && percent >= 80
+  return { used, limit, unlimited, percent, warning, exhausted }
 }

--- a/frontend/src/features/composer/api/syncScheduledPostsUsage.ts
+++ b/frontend/src/features/composer/api/syncScheduledPostsUsage.ts
@@ -1,14 +1,32 @@
 import type { QueryClient } from '@tanstack/react-query'
+import { notifications } from '@mantine/notifications'
 import { scheduledPostKeys } from '@/entities/scheduled-post'
 import type { Post } from '@/entities/scheduled-post'
-import { setUsage } from '@/entities/subscription'
+import { setUsage, subscriptionKeys } from '@/entities/subscription'
+import type { Subscription } from '@/entities/subscription'
 
 /**
  * Пересчитывает счётчик запланированных постов в моке подписки после мутаций,
  * чтобы PlanWidget в сайдбаре сразу показывал актуальное «N из M».
+ * Мягкий enforcement (#211): в момент исчерпания квоты показываем уведомление —
+ * призыв к апгрейду (кнопка «Улучшить тариф») живёт в баннере и виджете тарифа.
  */
 export function syncScheduledPostsUsage(queryClient: QueryClient) {
   const posts = queryClient.getQueryData<Post[]>(scheduledPostKeys.all) ?? []
   const scheduled = posts.filter((post) => post.status === 'scheduled').length
+
+  const before = queryClient.getQueryData<Subscription>(subscriptionKeys.all)
   setUsage(queryClient, { scheduledPosts: scheduled })
+
+  // Уведомляем один раз — когда мутация пересекла границу лимита (не был исчерпан → исчерпан)
+  const limit = before?.limits.scheduledPosts ?? Infinity
+  const wasExhausted = (before?.usage.scheduledPosts ?? 0) >= limit
+  const nowExhausted = Number.isFinite(limit) && scheduled >= limit
+  if (nowExhausted && !wasExhausted) {
+    notifications.show({
+      color: 'orange',
+      title: 'Достигнут лимит тарифа',
+      message: `Запланировано ${scheduled} из ${limit} постов в месяц — улучшите тариф, чтобы планировать больше.`,
+    })
+  }
 }

--- a/frontend/src/features/composer/ui/ComposerModal.tsx
+++ b/frontend/src/features/composer/ui/ComposerModal.tsx
@@ -77,6 +77,10 @@ export function ComposerModal({ opened, postId, onClose }: ComposerModalProps) {
 
   const queryClient = useQueryClient()
   const aiQuota = useQuota('ai')
+  // Мягкий enforcement квоты постов (#211): блокируем только СОЗДАНИЕ —
+  // редактирование существующего поста лимит не расходует.
+  const postsQuota = useQuota('posts')
+  const postsBlocked = !isEditing && postsQuota.exhausted
   const [timeOpen, setTimeOpen] = useState(false)
 
   const form = useForm<ComposerFormValues>({ initialValues: makeDefaultValues() })
@@ -136,7 +140,7 @@ export function ComposerModal({ opened, postId, onClose }: ComposerModalProps) {
   }
 
   const handleSubmit = form.onSubmit((values) => {
-    if (selectedCount === 0) return
+    if (selectedCount === 0 || postsBlocked) return
     const mediaCount = values.kind === 'video' ? 0 : values.attachments.length
     const draft = {
       title: buildPostTitle(values),
@@ -536,19 +540,21 @@ export function ComposerModal({ opened, postId, onClose }: ComposerModalProps) {
                 Удалить пост
               </UnstyledButton>
             )}
-            <Text fz="sm" c="dimmed" ml="auto">
-              {selectedCount === 0
-                ? 'Выберите хотя бы одну площадку'
-                : `Выйдет ${selectedCount} ${plural(selectedCount, [
-                    'публикация',
-                    'публикации',
-                    'публикаций',
-                  ])}`}
+            <Text fz="sm" c={postsBlocked ? 'red.7' : 'dimmed'} ml="auto">
+              {postsBlocked
+                ? 'Достигнут лимит постов тарифа — улучшите тариф'
+                : selectedCount === 0
+                  ? 'Выберите хотя бы одну площадку'
+                  : `Выйдет ${selectedCount} ${plural(selectedCount, [
+                      'публикация',
+                      'публикации',
+                      'публикаций',
+                    ])}`}
             </Text>
             <Button variant="default" onClick={handleClose}>
               Отмена
             </Button>
-            <Button type="submit" disabled={selectedCount === 0}>
+            <Button type="submit" disabled={selectedCount === 0 || postsBlocked}>
               {isEditing ? 'Сохранить' : 'В отложку'}
             </Button>
           </Group>

--- a/frontend/src/features/upgrade-plan/ui/UpgradePlanModal.tsx
+++ b/frontend/src/features/upgrade-plan/ui/UpgradePlanModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import {
   Alert,
   Badge,
@@ -15,7 +15,10 @@ import {
   ThemeIcon,
 } from '@mantine/core'
 import { notifications } from '@mantine/notifications'
-import { IconCheck, IconFileInvoice } from '@tabler/icons-react'
+import { useQueryClient } from '@tanstack/react-query'
+import { IconAlertTriangle, IconCheck, IconFileInvoice } from '@tabler/icons-react'
+import dayjs from 'dayjs'
+import { applyPlan, useSubscription } from '@/entities/subscription'
 
 /**
  * Глобальная модалка апгрейда тарифа. Состояние открытия приходит пропсами
@@ -23,15 +26,13 @@ import { IconCheck, IconFileInvoice } from '@tabler/icons-react'
  *
  * Трёхшаговый флоу (Mantine Stepper): выбор тарифа → оплата → готово. Всё локальное и
  * демо: тарифы захардкожены (страницу /pricing НЕ импортируем), данные карты не сохраняем.
+ * После успешной «оплаты» тариф и лимиты применяются к мок-подписке (entities/subscription).
  */
 
 const BRAND = '#2B50EC'
 const GREEN = '#1E7F4F'
 const BORDER = 'rgba(23,21,15,.13)'
 const PANEL = '#F6F4EF'
-
-/** Текущий тариф пользователя (демо). TODO (Design First, backlog #204): GET /billing/subscription. */
-const CURRENT_TARIFF = 'Бесплатный'
 
 type BillingPeriod = 'monthly' | 'yearly'
 
@@ -46,6 +47,8 @@ interface Plan {
   note: string
   /** Список включённых возможностей. */
   feats: string[]
+  /** Лимиты тарифа для мок-подписки; Infinity — безлимит постов на платных тарифах. */
+  limits: { aiRequests: number; scheduledPosts: number }
   /** Рекомендуемый тариф (выделяется рамкой и бейджем). */
   featured?: boolean
 }
@@ -58,6 +61,7 @@ const PLANS: Plan[] = [
     monthly: 0,
     note: 'навсегда',
     feats: ['3 соцсети', '10 постов в месяц', '1 проект', '5 ИИ-текстов в месяц'],
+    limits: { aiRequests: 5, scheduledPosts: 10 },
   },
   {
     id: 'start',
@@ -66,6 +70,7 @@ const PLANS: Plan[] = [
     note: '7 дней бесплатно',
     featured: true,
     feats: ['7 соцсетей', 'Посты без лимита', '1 проект', '50 ИИ-текстов в месяц'],
+    limits: { aiRequests: 50, scheduledPosts: Infinity },
   },
   {
     id: 'pro',
@@ -73,8 +78,15 @@ const PLANS: Plan[] = [
     monthly: 990,
     note: '7 дней бесплатно',
     feats: ['Всё из «Старта»', '5 проектов', 'Команда из 3 человек', 'Согласование постов'],
+    limits: { aiRequests: 50, scheduledPosts: Infinity },
   },
 ]
+
+// Мок платёжного шлюза: карта с номером, оканчивающимся на «0000», всегда даёт
+// ошибку оплаты (детерминированно для демо и ревью), любой другой номер — успех.
+const FAIL_CARD_SUFFIX = '0000'
+/** Задержка мок-«оплаты», мс — имитация запроса к шлюзу. */
+const PAY_DELAY = 700
 
 /** Цена за месяц с учётом периода (годовой — со скидкой 20%). */
 function monthlyPrice(plan: Plan, period: BillingPeriod): number {
@@ -97,7 +109,8 @@ interface UpgradePlanModalProps {
 }
 
 export function UpgradePlanModal({ opened, onClose }: UpgradePlanModalProps) {
-  const [activeTariff, setActiveTariff] = useState(CURRENT_TARIFF)
+  // Текущий тариф — из мок-подписки: после успешной «оплаты» бейдж обновится сам
+  const { data: subscription } = useSubscription()
 
   return (
     <Modal
@@ -112,30 +125,47 @@ export function UpgradePlanModal({ opened, onClose }: UpgradePlanModalProps) {
             Апгрейд тарифа
           </Text>
           <Badge color="gray" variant="light" radius="xl" tt="none" fw={600}>
-            сейчас: {activeTariff}
+            сейчас: {subscription.plan}
           </Badge>
         </Group>
       }
     >
-      <UpgradeFlow activeTariff={activeTariff} onPaid={setActiveTariff} onClose={onClose} />
+      <UpgradeFlow onClose={onClose} />
     </Modal>
   )
 }
 
 interface UpgradeFlowProps {
-  activeTariff: string
-  onPaid: (tariff: string) => void
   onClose: () => void
 }
 
+/** Статус мок-оплаты на шаге 2. */
+type PayStatus = 'idle' | 'loading' | 'error'
+
 /**
  * Трёхшаговый флоу апгрейда. Живёт в детях модалки: Mantine размонтирует их при
- * закрытии, поэтому каждое открытие начинается с шага 0 без ручного сброса.
+ * закрытии, поэтому каждое открытие начинается с шага 0 (и без «залипшей» ошибки
+ * оплаты) без ручного сброса.
  */
-function UpgradeFlow({ activeTariff, onPaid, onClose }: UpgradeFlowProps) {
+function UpgradeFlow({ onClose }: UpgradeFlowProps) {
+  const queryClient = useQueryClient()
+  const { data: subscription } = useSubscription()
   const [step, setStep] = useState(0)
   const [period, setPeriod] = useState<BillingPeriod>('monthly')
   const [selectedId, setSelectedId] = useState<string | null>(null)
+  // Номер карты держим только в локальном состоянии ради демо-правила «...0000 = ошибка»;
+  // никуда не сохраняем и не логируем.
+  const [cardNumber, setCardNumber] = useState('')
+  const [payStatus, setPayStatus] = useState<PayStatus>('idle')
+  const payTimer = useRef<number | null>(null)
+
+  // Модалка может закрыться во время «оплаты» — гасим таймер, чтобы результат не применился
+  useEffect(
+    () => () => {
+      if (payTimer.current != null) window.clearTimeout(payTimer.current)
+    },
+    [],
+  )
 
   const selectedPlan = PLANS.find((p) => p.id === selectedId) ?? null
 
@@ -147,19 +177,45 @@ function UpgradeFlow({ activeTariff, onPaid, onClose }: UpgradeFlowProps) {
     setStep(1)
   }
 
+  // Навигация между шагами сбрасывает результат прошлой попытки оплаты
+  const goToStep = (next: number) => {
+    setPayStatus('idle')
+    setStep(next)
+  }
+
   const pay = () => {
+    if (!selectedPlan || payStatus === 'loading') return
+    setPayStatus('loading')
     // TODO (Design First, backlog #204): POST /billing/subscription { plan, period, paymentMethod }.
     // Данные карты на фронте НЕ храним — они уходят напрямую в платёжный шлюз.
-    if (selectedPlan) onPaid(selectedPlan.name)
-    notifications.show({ color: 'green', message: 'Тариф изменён (демо)' })
-    setStep(2)
+    payTimer.current = window.setTimeout(() => {
+      // Демо-правило: номер карты, оканчивающийся на «0000», — ошибка оплаты, иначе успех
+      if (cardNumber.replace(/\D/g, '').endsWith(FAIL_CARD_SUFFIX)) {
+        setPayStatus('error')
+        return
+      }
+      // Успех: применяем тариф к мок-подписке — сайдбар и квоты обновляются сразу
+      applyPlan(queryClient, {
+        plan: selectedPlan.name,
+        limits: selectedPlan.limits,
+        renewsAt: dayjs()
+          .add(1, period === 'yearly' ? 'year' : 'month')
+          .format('YYYY-MM-DD'),
+      })
+      notifications.show({ color: 'green', message: 'Тариф изменён (демо)' })
+      setPayStatus('idle')
+      setStep(2)
+    }, PAY_DELAY)
   }
 
   return (
     <>
-      <Stepper active={step} onStepClick={setStep} size="sm" allowNextStepsSelect={false} mb="lg">
-        <Stepper.Step label="Выбор тарифа" allowStepSelect={step === 2 ? false : true} />
-        <Stepper.Step label="Оплата" allowStepSelect={step > 0 && step < 2} />
+      <Stepper active={step} onStepClick={goToStep} size="sm" allowNextStepsSelect={false} mb="lg">
+        <Stepper.Step
+          label="Выбор тарифа"
+          allowStepSelect={step === 1 && payStatus !== 'loading'}
+        />
+        <Stepper.Step label="Оплата" allowStepSelect={false} />
         <Stepper.Step label="Готово" allowStepSelect={false} />
       </Stepper>
 
@@ -289,6 +345,8 @@ function UpgradeFlow({ activeTariff, onPaid, onClose }: UpgradeFlowProps) {
             label="Номер карты"
             placeholder="2200 1234 5678 9012"
             inputMode="numeric"
+            value={cardNumber}
+            onChange={(event) => setCardNumber(event.currentTarget.value)}
             styles={{ input: { letterSpacing: 1 } }}
           />
 
@@ -307,17 +365,36 @@ function UpgradeFlow({ activeTariff, onPaid, onClose }: UpgradeFlowProps) {
             Или оплата по счёту для юрлиц — пришлём счёт и закрывающие документы.
           </Alert>
 
+          {/* Ошибка мок-оплаты: остаёмся на шаге 2, данные можно поправить и повторить */}
+          {payStatus === 'error' && (
+            <Alert
+              color="red"
+              variant="light"
+              radius="md"
+              icon={<IconAlertTriangle size={18} />}
+              styles={{ message: { fontSize: 13 } }}
+            >
+              Не удалось провести оплату. Проверьте данные карты и попробуйте снова.
+            </Alert>
+          )}
+
           <Group justify="space-between" mt="xs">
-            <Button variant="subtle" color="gray" onClick={() => setStep(0)}>
+            <Button
+              variant="subtle"
+              color="gray"
+              disabled={payStatus === 'loading'}
+              onClick={() => goToStep(0)}
+            >
               ← Назад
             </Button>
-            <Button color="brand" onClick={pay}>
+            <Button color="brand" loading={payStatus === 'loading'} onClick={pay}>
               Оплатить {totalLabel}
             </Button>
           </Group>
 
           <Text ta="center" fz={11.5} c="rgba(23,21,15,.45)">
-            Это демо — ничего не спишется. Данные карты мы не храним.
+            Это демо — ничего не спишется, данные карты мы не храним. Номер на ...
+            {FAIL_CARD_SUFFIX} покажет ошибку оплаты.
           </Text>
         </Stack>
       )}
@@ -334,8 +411,8 @@ function UpgradeFlow({ activeTariff, onPaid, onClose }: UpgradeFlowProps) {
           </Text>
 
           <Text maw={380} ta="center" fz={13.5} lh={1.55} c="rgba(23,21,15,.6)">
-            Тариф «{activeTariff}» активен. Новые лимиты уже применены к проекту — можно подключать
-            площадки и планировать посты без ограничений.
+            Тариф «{subscription.plan}» активен. Новые лимиты уже применены к проекту — можно
+            подключать площадки и планировать посты без ограничений.
           </Text>
 
           <Button mt="sm" color="brand" onClick={onClose}>

--- a/frontend/src/pages/content-plan/ui/ContentPlanPage.tsx
+++ b/frontend/src/pages/content-plan/ui/ContentPlanPage.tsx
@@ -8,6 +8,7 @@ import {
   Stack,
   Text,
   Title,
+  Tooltip,
   UnstyledButton,
 } from '@mantine/core'
 import { IconLink, IconPlus } from '@tabler/icons-react'
@@ -15,6 +16,7 @@ import dayjs from 'dayjs'
 import { useAppModals } from '@/features/app-modals'
 import { useCalendarFilter } from '@/features/filter-by-platform'
 import { isInWeek, startOfWeekMonday, useContentPlan } from '@/entities/scheduled-post'
+import { useQuota } from '@/entities/subscription'
 import { BORDER_PANEL, BRAND, BRAND_SOFT_BG, INK } from '../lib/palette'
 import { capitalize, postCountLabel } from '../lib/format'
 import { PlatformChips } from './PlatformChips'
@@ -39,6 +41,7 @@ export function ContentPlanPage() {
   const [weekOffset, setWeekOffset] = useState(0)
   const [calYear, setCalYear] = useState(() => dayjs().year())
   const { openComposer, openConnectPlatform } = useAppModals()
+  const postsQuota = useQuota('posts')
   const { data: posts, isLoading } = useContentPlan()
   const { activeNetworkIds } = useCalendarFilter()
 
@@ -153,9 +156,27 @@ export function ContentPlanPage() {
           >
             Подключить площадку
           </Button>
-          <Button leftSection={<IconPlus size={16} />} onClick={() => openComposer()}>
-            Новый пост
-          </Button>
+          {/* Мягкий enforcement квоты постов (#211): при исчерпании кнопка
+              неактивна, тултип объясняет причину. data-disabled вместо disabled,
+              чтобы Tooltip продолжал работать. */}
+          <Tooltip
+            label="Достигнут лимит постов тарифа — улучшите тариф, чтобы планировать больше"
+            disabled={!postsQuota.exhausted}
+          >
+            <Button
+              leftSection={<IconPlus size={16} />}
+              data-disabled={postsQuota.exhausted || undefined}
+              onClick={(event) => {
+                if (postsQuota.exhausted) {
+                  event.preventDefault()
+                  return
+                }
+                openComposer()
+              }}
+            >
+              Новый пост
+            </Button>
+          </Tooltip>
         </Group>
       </Group>
 

--- a/frontend/src/widgets/app-shell/ui/AppLayout.tsx
+++ b/frontend/src/widgets/app-shell/ui/AppLayout.tsx
@@ -1,4 +1,5 @@
 import {
+  Alert,
   Anchor,
   AppShell,
   Avatar,
@@ -15,6 +16,7 @@ import {
 } from '@mantine/core'
 import { useDisclosure } from '@mantine/hooks'
 import {
+  IconAlertTriangle,
   IconCalendar,
   IconChartBar,
   IconCheck,
@@ -32,6 +34,7 @@ import 'dayjs/locale/ru'
 import { Logo } from '@/shared/ui'
 import { useCurrentProject, useProjects, setCurrentProject } from '@/entities/project'
 import { useSubscription, useQuota } from '@/entities/subscription'
+import type { QuotaState } from '@/entities/subscription'
 import { mediaKeys } from '@/entities/media'
 import { scheduledPostKeys } from '@/entities/scheduled-post'
 import { logout } from '@/entities/session'
@@ -162,19 +165,44 @@ function ProjectSwitcher({ onNewProject }: { onNewProject: () => void }) {
   )
 }
 
+interface QuotaLineProps {
+  label: string
+  quota: QuotaState
+}
+
+/** Строка квоты в виджете тарифа: счётчик и прогресс-бар с подсветкой порогов из useQuota. */
+function QuotaLine({ label, quota }: QuotaLineProps) {
+  if (quota.unlimited) {
+    return (
+      <Text fz={11} c="dimmed" mb={6}>
+        {label}: безлимит
+      </Text>
+    )
+  }
+  return (
+    <Box mb={6}>
+      <Text fz={11} c={quota.exhausted ? 'red.7' : quota.warning ? 'orange.8' : 'dimmed'} mb={4}>
+        {label}: {quota.used} / {quota.limit}
+      </Text>
+      <Progress
+        value={quota.percent}
+        size="sm"
+        color={quota.exhausted ? 'red' : quota.warning ? 'orange' : 'brand'}
+      />
+    </Box>
+  )
+}
+
 function PlanWidget() {
   const { openUpgrade } = useAppModals()
   const { data: subscription } = useSubscription()
-  const { used, limit, exhausted } = useQuota('ai')
+  const ai = useQuota('ai')
+  const posts = useQuota('posts')
 
-  // Безлимитный тариф: показываем «безлимит» без счётчика и прогресс-бара
-  const unlimited = !Number.isFinite(limit)
-  const percent = unlimited ? 0 : Math.min(100, Math.round((used / limit) * 100))
-  // Подсветка: с ~80% — предупреждение, при исчерпании — цвет ошибки
-  const nearLimit = !unlimited && !exhausted && percent >= 80
-  const quotaColor = exhausted ? 'red' : nearLimit ? 'orange' : 'brand'
-  // На «Старте» предлагаем улучшение, на остальных тарифах — смену
-  const upgradeLabel = subscription.plan === 'Старт' ? 'Улучшить тариф' : 'Сменить тариф'
+  // Квоты требуют внимания: акцентная кнопка и явный призыв улучшить тариф
+  const attention = ai.exhausted || ai.warning || posts.exhausted || posts.warning
+  const upgradeLabel =
+    attention || subscription.plan === 'Старт' ? 'Улучшить тариф' : 'Сменить тариф'
   const renewsLabel = `до ${dayjs(subscription.renewsAt).locale('ru').format('D MMM').replace('.', '')}`
 
   return (
@@ -194,32 +222,65 @@ function PlanWidget() {
           {renewsLabel}
         </Text>
       </Group>
-      {unlimited ? (
-        <Text fz={11} c="dimmed" mb="xs">
-          ИИ-тексты: безлимит
+      <QuotaLine label="ИИ-тексты" quota={ai} />
+      <QuotaLine label="Посты" quota={posts} />
+      {posts.exhausted ? (
+        <Text fz={11} c="red.7" mt={2} mb="xs">
+          Достигнут лимит тарифа: {posts.limit} постов в месяц
+        </Text>
+      ) : ai.exhausted ? (
+        <Text fz={11} c="red.7" mt={2} mb="xs">
+          Лимит ИИ-текстов на период исчерпан — поднимите его апгрейдом тарифа
+        </Text>
+      ) : posts.warning ? (
+        <Text fz={11} c="orange.8" mt={2} mb="xs">
+          Осталось {posts.limit - posts.used} из {posts.limit} постов до лимита
         </Text>
       ) : (
-        <>
-          <Text fz={11} c={exhausted ? 'red.7' : nearLimit ? 'orange.8' : 'dimmed'} mb={4}>
-            ИИ-тексты: {used} / {limit}
-          </Text>
-          <Progress value={percent} size="sm" color={quotaColor} mb="sm" />
-          {exhausted && (
-            <Text fz={11} c="red.7" mb="xs">
-              Лимит на период исчерпан — поднимите его апгрейдом тарифа
-            </Text>
-          )}
-        </>
+        <Box mt={2} mb="xs" />
       )}
-      <Button
-        size="xs"
-        variant={exhausted || nearLimit ? 'filled' : 'light'}
-        fullWidth
-        onClick={openUpgrade}
-      >
+      <Button size="xs" variant={attention ? 'filled' : 'light'} fullWidth onClick={openUpgrade}>
         {upgradeLabel} →
       </Button>
     </Box>
+  )
+}
+
+/**
+ * Мягкий enforcement лимита постов (#211): баннер над контентом кабинета.
+ * Оранжевое предупреждение при приближении к лимиту и красный призыв к апгрейду
+ * при исчерпании; блокировка самих кнопок создания — на экранах и в композере.
+ */
+function PostsQuotaBanner() {
+  const { openUpgrade } = useAppModals()
+  const posts = useQuota('posts')
+
+  if (!posts.exhausted && !posts.warning) return null
+
+  return (
+    <Alert
+      color={posts.exhausted ? 'red' : 'orange'}
+      variant="light"
+      radius="md"
+      mb="md"
+      icon={<IconAlertTriangle size={18} />}
+      title={
+        posts.exhausted
+          ? `Достигнут лимит тарифа: ${posts.limit} постов в месяц`
+          : 'Лимит постов почти исчерпан'
+      }
+    >
+      <Group justify="space-between" gap="sm">
+        <Text fz={13} style={{ flex: 1, minWidth: 220 }}>
+          {posts.exhausted
+            ? 'Новые посты не запланируются, пока не освободится квота. Улучшите тариф, чтобы публиковать без ограничений.'
+            : `Запланировано ${posts.used} из ${posts.limit} постов в месяц. Улучшите тариф, чтобы не останавливать публикации.`}
+        </Text>
+        <Button size="xs" color={posts.exhausted ? 'red' : 'orange'} onClick={openUpgrade}>
+          Улучшить тариф
+        </Button>
+      </Group>
+    </Alert>
   )
 }
 
@@ -294,6 +355,7 @@ export function AppLayout() {
       </AppShell.Navbar>
 
       <AppShell.Main>
+        <PostsQuotaBanner />
         <Outlet />
       </AppShell.Main>
 


### PR DESCRIPTION
Closes #211

Стек: после PR #188-oauth-callback.

- useQuota расширен (unlimited/percent/warning — пороги в хуке); PlanWidget показывает ОБЕ квоты (ИИ + посты) с прогресс-барами и подсказками; кнопка «Улучшить тариф» при проблемах
- PostsQuotaBanner в кабинете: оранжевое предупреждение при приближении, красный баннер при исчерпании, кнопка → модалка апгрейда
- syncScheduledPostsUsage: уведомление при пересечении лимита; мутации постов инкрементят usage
- **Второй коммит (доводка критериев):** «Новый пост» на календаре — data-disabled + тултип при исчерпании; сабмит композера «В отложку» заблокирован с красной подсказкой (только создание — редактирование лимит не тратит)

Проверено агентом вживую: 9/10 → оранжевый баннер, 10/10 → красный + блокировки, создание поста двигает счётчик синхронно с сайдбаром. Известная демо-условность: SEED «Бесплатный» даёт лимит ИИ 50 (как в макете сайдбара), а PLANS модалки — «5 ИИ-текстов» (как на тарифах) — расхождение в самом дизайне, отмечено в коде.