### PR TITLE
feat(frontend): отчёты — loading/error и рабочий экспорт CSV

### DIFF
--- a/frontend/src/entities/member/index.ts
+++ b/frontend/src/entities/member/index.ts
@@ -1,3 +1,4 @@
 export { useMembers } from './model/useMembers'
+export { useCurrentMemberRole } from './model/useCurrentMember'
 export { ROLE_LABELS } from './model/types'
 export type { Member, MemberRole, MemberStatus } from './model/types'

--- a/frontend/src/entities/member/model/useCurrentMember.ts
+++ b/frontend/src/entities/member/model/useCurrentMember.ts
@@ -1,0 +1,16 @@
+import type { MemberRole } from './types'
+
+/**
+ * Роль «текущего пользователя проекта» — мок Design First: кто залогинен и
+ * какая у него роль, появится с бэкендом и интеграцией API (#147).
+ *
+ * По умолчанию — владелец, чтобы демо оставалось интерактивным. Чтобы
+ * проверить режим «только чтение» на странице «Команда», временно поставьте
+ * 'author' или 'editor'.
+ */
+const CURRENT_MEMBER_ROLE: MemberRole = 'owner'
+
+/** Роль текущего пользователя в проекте (мок). */
+export function useCurrentMemberRole(): MemberRole {
+  return CURRENT_MEMBER_ROLE
+}

--- a/frontend/src/entities/report/api/reportApi.ts
+++ b/frontend/src/entities/report/api/reportApi.ts
@@ -1,0 +1,39 @@
+import {
+  PERIOD_MULTIPLIER,
+  REPORT_DELAY_MS,
+  REPORT_ROWS_WEEK,
+  SIMULATE_REPORT_ERROR,
+  YEAR_MULTIPLIER,
+} from '../model/mock'
+import type { ReportRow } from '../model/types'
+
+export const reportKeys = {
+  all: ['report'] as const,
+  byFilter: (period: string, year: string) => ['report', period, year] as const,
+}
+
+/**
+ * Мок-загрузка отчёта по площадкам за выбранный период и год.
+ *
+ * Недельные значения масштабируются множителем периода и коэффициентом года
+ * (как в макете). Задержка эмулирует сеть, чтобы лоадер был реально виден.
+ *
+ * TODO (Design First): заменить на GET /projects/{id}/reports?period=&year=
+ * (эндпоинт появится в бэкенде, см. #147).
+ */
+export async function fetchReport(period: string, year: string): Promise<ReportRow[]> {
+  await new Promise((resolve) => setTimeout(resolve, REPORT_DELAY_MS))
+
+  if (SIMULATE_REPORT_ERROR) {
+    throw new Error('Не удалось загрузить отчёт')
+  }
+
+  const mult = (PERIOD_MULTIPLIER[period] ?? 1) * (YEAR_MULTIPLIER[year] ?? 1)
+  return REPORT_ROWS_WEEK.map((row) => ({
+    networkId: row.networkId,
+    publications: Math.round(row.publications * mult),
+    views: Math.round(row.views * mult),
+    likes: Math.round(row.likes * mult),
+    reposts: Math.round(row.reposts * mult),
+  }))
+}

--- a/frontend/src/entities/report/model/hooks.ts
+++ b/frontend/src/entities/report/model/hooks.ts
@@ -1,27 +1,27 @@
-import { useMemo } from 'react'
-import { PERIOD_MULTIPLIER, REPORT_ROWS_WEEK, YEAR_MULTIPLIER } from './mock'
+import { useQuery } from '@tanstack/react-query'
+import { fetchReport, reportKeys } from '../api/reportApi'
 import type { ReportRow } from './types'
 
 /**
  * Отчёт по площадкам за выбранный период и год.
  *
- * Пока считает демо-цифры из локального мока: недельные значения
- * масштабируются множителем периода и коэффициентом года (как в макете).
+ * Мок на react-query: данные приходят с задержкой (без initialData),
+ * поэтому при первой отрисовке и при смене фильтров виден лоадер.
  *
- * TODO (Design First): заменить на react-query поверх
+ * TODO (Design First): заменить queryFn на react-query поверх
  * GET /projects/{id}/reports?period=&year= (эндпоинт появится в бэкенде).
  */
-export function useReport(period: string, year: string): { data: ReportRow[] } {
-  const data = useMemo<ReportRow[]>(() => {
-    const mult = (PERIOD_MULTIPLIER[period] ?? 1) * (YEAR_MULTIPLIER[year] ?? 1)
-    return REPORT_ROWS_WEEK.map((row) => ({
-      networkId: row.networkId,
-      publications: Math.round(row.publications * mult),
-      views: Math.round(row.views * mult),
-      likes: Math.round(row.likes * mult),
-      reposts: Math.round(row.reposts * mult),
-    }))
-  }, [period, year])
+export function useReport(
+  period: string,
+  year: string,
+): { data: ReportRow[]; isLoading: boolean; error: unknown } {
+  const query = useQuery({
+    queryKey: reportKeys.byFilter(period, year),
+    queryFn: () => fetchReport(period, year),
+    // Кэш не держим: при каждой смене периода/года лоадер снова виден (критерий приёмки).
+    gcTime: 0,
+  })
 
-  return { data }
+  // Сигнатура — надмножество прежней: data всегда массив, как раньше.
+  return { data: query.data ?? [], isLoading: query.isLoading, error: query.error }
 }

--- a/frontend/src/entities/report/model/mock.ts
+++ b/frontend/src/entities/report/model/mock.ts
@@ -18,6 +18,15 @@ export const REPORT_ROWS_WEEK: ReportRow[] = [
   { networkId: 'rutube', publications: 2, views: 950, likes: 70, reposts: 12 },
 ]
 
+/** Имитация сетевой задержки мок-загрузки отчёта, мс. */
+export const REPORT_DELAY_MS = 500
+
+/**
+ * Флаг для проверки состояния ошибки: поставьте true — и вместо таблицы
+ * страница покажет сообщение об ошибке (QueryState). В демо всегда false.
+ */
+export const SIMULATE_REPORT_ERROR = false
+
 /** Множитель длины периода относительно недели (из макета: REP_MULT). */
 export const PERIOD_MULTIPLIER: Record<string, number> = {
   week: 1,

--- a/frontend/src/pages/reports/ui/ReportsPage.tsx
+++ b/frontend/src/pages/reports/ui/ReportsPage.tsx
@@ -1,10 +1,9 @@
 import { useState } from 'react'
 import { Box, Button, Group, Select, Stack, Table, Text, Title } from '@mantine/core'
-import { notifications } from '@mantine/notifications'
 import { IconDownload } from '@tabler/icons-react'
 import { NETWORKS } from '@/shared/config'
 import type { Network } from '@/shared/config'
-import { EmptyState, NetworkPill } from '@/shared/ui'
+import { EmptyState, NetworkPill, QueryState } from '@/shared/ui'
 import { useReport } from '@/entities/report'
 import type { ReportRow } from '@/entities/report'
 
@@ -33,12 +32,7 @@ export function ReportsPage() {
   const [period, setPeriod] = useState<string>('week')
   const [year, setYear] = useState<string>('2026')
 
-  const { data } = useReport(period, year)
-
-  const handleDownload = () => {
-    // TODO (Design First): GET /projects/{id}/reports/export?period=&year= (эндпоинт появится в бэкенде).
-    notifications.show({ color: 'green', message: 'Отчёт готовится к скачиванию (демо)' })
-  }
+  const { data, isLoading, error } = useReport(period, year)
 
   const totals = data.reduce(
     (acc, row) => ({
@@ -50,11 +44,42 @@ export function ReportsPage() {
     { publications: 0, views: 0, likes: 0, reposts: 0 } satisfies Omit<ReportRow, 'networkId'>,
   )
 
+  const handleDownload = () => {
+    // TODO (Design First): заменить на GET /projects/{id}/reports/export?period=&year=
+    // (эндпоинт появится в бэкенде). Пока собираем CSV из текущих мок-данных таблицы.
+    const header = ['Площадка', 'Публикации', 'Просмотры', 'Лайки', 'Репосты']
+    const rows = data.map((row) => [
+      findNetwork(row.networkId)?.name ?? row.networkId,
+      row.publications,
+      row.views,
+      row.likes,
+      row.reposts,
+    ])
+    const totalsRow = ['Итого', totals.publications, totals.views, totals.likes, totals.reposts]
+    const csv = [header, ...rows, totalsRow].map((cells) => cells.join(';')).join('\n')
+
+    // BOM в начале — чтобы Excel корректно распознал кириллицу в UTF-8.
+    const blob = new Blob(['\uFEFF' + csv], { type: 'text/csv;charset=utf-8' })
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement('a')
+    link.href = url
+    link.download = `report-${period}-${year}.csv`
+    document.body.appendChild(link)
+    link.click()
+    link.remove()
+    URL.revokeObjectURL(url)
+  }
+
   return (
     <Stack gap="lg">
       <Group justify="space-between" align="flex-end" wrap="wrap" gap="md">
         <Title order={2}>Отчёты</Title>
-        <Button variant="default" leftSection={<IconDownload size={16} />} onClick={handleDownload}>
+        <Button
+          variant="default"
+          leftSection={<IconDownload size={16} />}
+          onClick={handleDownload}
+          disabled={isLoading || Boolean(error) || data.length === 0}
+        >
           Скачать отчёт
         </Button>
       </Group>
@@ -78,55 +103,57 @@ export function ReportsPage() {
         />
       </Group>
 
-      {data.length === 0 ? (
-        <EmptyState
-          title="Пока нет данных для отчёта"
-          description="Подключите площадки и опубликуйте посты — статистика появится здесь."
-        />
-      ) : (
-        <Box style={{ overflowX: 'auto' }}>
-          <Table miw={640} verticalSpacing="sm" highlightOnHover>
-            <Table.Thead>
-              <Table.Tr>
-                <Table.Th>Площадка</Table.Th>
-                <Table.Th ta="right">Публикации</Table.Th>
-                <Table.Th ta="right">Просмотры</Table.Th>
-                <Table.Th ta="right">Лайки</Table.Th>
-                <Table.Th ta="right">Репосты</Table.Th>
-              </Table.Tr>
-            </Table.Thead>
-            <Table.Tbody>
-              {data.map((row) => {
-                const network = findNetwork(row.networkId)
-                return (
-                  <Table.Tr key={row.networkId}>
-                    <Table.Td>
-                      {network ? (
-                        <NetworkPill network={network} />
-                      ) : (
-                        <Text size="sm">{row.networkId}</Text>
-                      )}
-                    </Table.Td>
-                    <Table.Td ta="right">{formatNumber(row.publications)}</Table.Td>
-                    <Table.Td ta="right">{formatNumber(row.views)}</Table.Td>
-                    <Table.Td ta="right">{formatNumber(row.likes)}</Table.Td>
-                    <Table.Td ta="right">{formatNumber(row.reposts)}</Table.Td>
-                  </Table.Tr>
-                )
-              })}
-            </Table.Tbody>
-            <Table.Tfoot>
-              <Table.Tr>
-                <Table.Th>Итого</Table.Th>
-                <Table.Th ta="right">{formatNumber(totals.publications)}</Table.Th>
-                <Table.Th ta="right">{formatNumber(totals.views)}</Table.Th>
-                <Table.Th ta="right">{formatNumber(totals.likes)}</Table.Th>
-                <Table.Th ta="right">{formatNumber(totals.reposts)}</Table.Th>
-              </Table.Tr>
-            </Table.Tfoot>
-          </Table>
-        </Box>
-      )}
+      <QueryState isLoading={isLoading} error={error}>
+        {data.length === 0 ? (
+          <EmptyState
+            title="Пока нет данных для отчёта"
+            description="Подключите площадки и опубликуйте посты — статистика появится здесь."
+          />
+        ) : (
+          <Box style={{ overflowX: 'auto' }}>
+            <Table miw={640} verticalSpacing="sm" highlightOnHover>
+              <Table.Thead>
+                <Table.Tr>
+                  <Table.Th>Площадка</Table.Th>
+                  <Table.Th ta="right">Публикации</Table.Th>
+                  <Table.Th ta="right">Просмотры</Table.Th>
+                  <Table.Th ta="right">Лайки</Table.Th>
+                  <Table.Th ta="right">Репосты</Table.Th>
+                </Table.Tr>
+              </Table.Thead>
+              <Table.Tbody>
+                {data.map((row) => {
+                  const network = findNetwork(row.networkId)
+                  return (
+                    <Table.Tr key={row.networkId}>
+                      <Table.Td>
+                        {network ? (
+                          <NetworkPill network={network} />
+                        ) : (
+                          <Text size="sm">{row.networkId}</Text>
+                        )}
+                      </Table.Td>
+                      <Table.Td ta="right">{formatNumber(row.publications)}</Table.Td>
+                      <Table.Td ta="right">{formatNumber(row.views)}</Table.Td>
+                      <Table.Td ta="right">{formatNumber(row.likes)}</Table.Td>
+                      <Table.Td ta="right">{formatNumber(row.reposts)}</Table.Td>
+                    </Table.Tr>
+                  )
+                })}
+              </Table.Tbody>
+              <Table.Tfoot>
+                <Table.Tr>
+                  <Table.Th>Итого</Table.Th>
+                  <Table.Th ta="right">{formatNumber(totals.publications)}</Table.Th>
+                  <Table.Th ta="right">{formatNumber(totals.views)}</Table.Th>
+                  <Table.Th ta="right">{formatNumber(totals.likes)}</Table.Th>
+                  <Table.Th ta="right">{formatNumber(totals.reposts)}</Table.Th>
+                </Table.Tr>
+              </Table.Tfoot>
+            </Table>
+          </Box>
+        )}
+      </QueryState>
 
       <Text size="sm" c="dimmed">
         Отчёт уходит в Telegram каждое воскресенье в 20:00 — настроить можно в разделе «Настройки».

--- a/frontend/src/pages/team/ui/TeamPage.tsx
+++ b/frontend/src/pages/team/ui/TeamPage.tsx
@@ -17,7 +17,7 @@ import { useForm } from '@mantine/form'
 import { notifications } from '@mantine/notifications'
 import { IconUserPlus } from '@tabler/icons-react'
 import { ConfirmDeleteButton, EmptyState } from '@/shared/ui'
-import { ROLE_LABELS, useMembers } from '@/entities/member'
+import { ROLE_LABELS, useCurrentMemberRole, useMembers } from '@/entities/member'
 import type { Member, MemberRole } from '@/entities/member'
 
 /** Данные для Mantine Select: value = роль, label = русское название. */
@@ -44,6 +44,12 @@ interface InviteFormValues {
 export function TeamPage() {
   const { data } = useMembers()
   const [members, setMembers] = useState<Member[]>(data)
+
+  // Гейтинг по роли ЗРИТЕЛЯ страницы (не по роли строки): менять роли,
+  // отзывать доступ и приглашать может только владелец проекта. Скрытие на
+  // фронте — только UX, реальную проверку прав делает бэкенд (#147).
+  const currentRole = useCurrentMemberRole()
+  const canManageTeam = currentRole === 'owner'
 
   const form = useForm<InviteFormValues>({
     initialValues: { email: '', role: 'author' },
@@ -134,27 +140,40 @@ export function TeamPage() {
                     </Badge>
                   )}
 
-                  <Select
-                    data={ROLE_OPTIONS}
-                    value={member.role}
-                    onChange={(value) => value && handleRoleChange(member.id, value as MemberRole)}
-                    disabled={member.role === 'owner'}
-                    allowDeselect={false}
-                    aria-label={`Роль участника ${member.name}`}
-                    w={130}
-                    style={{ flex: 'none' }}
-                  />
+                  {canManageTeam ? (
+                    <Select
+                      data={ROLE_OPTIONS}
+                      value={member.role}
+                      onChange={(value) =>
+                        value && handleRoleChange(member.id, value as MemberRole)
+                      }
+                      disabled={member.role === 'owner'}
+                      allowDeselect={false}
+                      aria-label={`Роль участника ${member.name}`}
+                      w={130}
+                      style={{ flex: 'none' }}
+                    />
+                  ) : (
+                    // Режим «только чтение»: роль — бейджем (владельца показывает бейдж ниже)
+                    member.role !== 'owner' && (
+                      <Badge color="gray" variant="light" style={{ flex: 'none' }}>
+                        {ROLE_LABELS[member.role]}
+                      </Badge>
+                    )
+                  )}
 
                   {member.role === 'owner' ? (
                     <Badge color="dark" variant="filled" style={{ flex: 'none' }}>
                       Владелец
                     </Badge>
                   ) : (
-                    <ConfirmDeleteButton
-                      onConfirm={() => handleRemove(member)}
-                      tooltip="Отозвать доступ к проекту"
-                      confirmText={`Отозвать доступ для ${member.name}?`}
-                    />
+                    canManageTeam && (
+                      <ConfirmDeleteButton
+                        onConfirm={() => handleRemove(member)}
+                        tooltip="Отозвать доступ к проекту"
+                        confirmText={`Отозвать доступ для ${member.name}?`}
+                      />
+                    )
                   )}
                 </Group>
               ))}
@@ -164,30 +183,39 @@ export function TeamPage() {
 
         {/* ===== Пригласить в команду ===== */}
         <Paper withBorder radius="md" p="lg">
-          <form onSubmit={handleInvite}>
+          {canManageTeam ? (
+            <form onSubmit={handleInvite}>
+              <Stack gap="md">
+                <Title order={4}>Пригласить в команду</Title>
+                <TextInput
+                  label="Почта"
+                  placeholder="kollega@example.ru"
+                  type="email"
+                  {...form.getInputProps('email')}
+                />
+                <Select
+                  label="Роль"
+                  data={ROLE_OPTIONS}
+                  allowDeselect={false}
+                  {...form.getInputProps('role')}
+                />
+                <Button type="submit" fullWidth leftSection={<IconUserPlus size={16} />}>
+                  Пригласить
+                </Button>
+                <Text size="xs" c="dimmed">
+                  Автор пишет черновики, редактор утверждает и публикует. Отозвать доступ можно в
+                  любой момент.
+                </Text>
+              </Stack>
+            </form>
+          ) : (
             <Stack gap="md">
               <Title order={4}>Пригласить в команду</Title>
-              <TextInput
-                label="Почта"
-                placeholder="kollega@example.ru"
-                type="email"
-                {...form.getInputProps('email')}
-              />
-              <Select
-                label="Роль"
-                data={ROLE_OPTIONS}
-                allowDeselect={false}
-                {...form.getInputProps('role')}
-              />
-              <Button type="submit" fullWidth leftSection={<IconUserPlus size={16} />}>
-                Пригласить
-              </Button>
-              <Text size="xs" c="dimmed">
-                Автор пишет черновики, редактор утверждает и публикует. Отозвать доступ можно в
-                любой момент.
+              <Text size="sm" c="dimmed">
+                Приглашать участников, менять роли и отзывать доступ может только владелец проекта.
               </Text>
             </Stack>
-          </form>
+          )}
         </Paper>
       </SimpleGrid>
     </Stack>


### PR DESCRIPTION
Closes #208

Стек: после PR #210-payment-error.

- useReport → useQuery (reportApi по эталону projectApi, задержка 500мс, gcTime 0 — лоадер виден при смене периода/года); QueryState для loading/error; флаг SIMULATE_REPORT_ERROR для проверки ошибки
- Экспорт CSV: Blob + download, «;»-разделитель, **BOM для кириллицы в Excel**, русские названия площадок, строка «Итого», имя report-<период>-<год>.csv; кнопка disabled при загрузке/ошибке/пустоте

Проверено: Node-тест CSV (BOM, итоги, масштабирование периода) + живой лоадер; в интеграционном смоуке таблица грузится, кнопка активна. lint/tsc/build чисто.