### PR TITLE
feat(frontend): настройки — две колонки, профиль с уведомлениями, тумблеры проекта

### DIFF
--- a/frontend/src/features/app-modals/model/appModalsSlice.ts
+++ b/frontend/src/features/app-modals/model/appModalsSlice.ts
@@ -8,13 +8,13 @@ import type { PayloadAction } from '@reduxjs/toolkit'
 export interface AppModalsState {
   composer: { opened: boolean; postId: string | null }
   upgrade: { opened: boolean }
-  connectPlatform: { opened: boolean }
+  connectPlatform: { opened: boolean; networkId: string | null }
 }
 
 const initialState: AppModalsState = {
   composer: { opened: false, postId: null },
   upgrade: { opened: false },
-  connectPlatform: { opened: false },
+  connectPlatform: { opened: false, networkId: null },
 }
 
 export const appModalsSlice = createSlice({
@@ -33,8 +33,9 @@ export const appModalsSlice = createSlice({
     closeUpgrade(state) {
       state.upgrade.opened = false
     },
-    openConnectPlatform(state) {
-      state.connectPlatform.opened = true
+    // С networkId — модалка конкретной площадки, без — общий список (как postId у composer)
+    openConnectPlatform(state, action: PayloadAction<string | undefined>) {
+      state.connectPlatform = { opened: true, networkId: action.payload ?? null }
     },
     closeConnectPlatform(state) {
       state.connectPlatform.opened = false

--- a/frontend/src/features/app-modals/model/hooks.ts
+++ b/frontend/src/features/app-modals/model/hooks.ts
@@ -19,7 +19,7 @@ export function useAppModals() {
     closeComposer: () => dispatch(closeComposer()),
     openUpgrade: () => dispatch(openUpgrade()),
     closeUpgrade: () => dispatch(closeUpgrade()),
-    openConnectPlatform: () => dispatch(openConnectPlatform()),
+    openConnectPlatform: (networkId?: string) => dispatch(openConnectPlatform(networkId)),
     closeConnectPlatform: () => dispatch(closeConnectPlatform()),
   }
 }

--- a/frontend/src/features/connect-platform/api/mockConnectApi.ts
+++ b/frontend/src/features/connect-platform/api/mockConnectApi.ts
@@ -1,0 +1,81 @@
+/**
+ * Мок-API подключения площадок: бэкенда пока нет, «OAuth»-авторизация и запросы
+ * эмулируются задержкой ~700мс (по образцу features/auth/api/mockAuthApi.ts).
+ * Ошибка триггерится заранее заданной площадкой (см. константу ниже) — так можно
+ * вручную проверить состояния loading/error. Реальные запросы к API и настоящий
+ * OAuth-редирект — отдельные backend-задачи и #147.
+ */
+
+/** Задержка мок-запроса, мс */
+const MOCK_DELAY_MS = 700
+
+/** Площадка-триггер ошибки: первая попытка авторизации в RUTUBE падает, повторная — успешна */
+export const MOCK_AUTH_ERROR_NETWORK_ID = 'rutube'
+
+const wait = () => new Promise((resolve) => setTimeout(resolve, MOCK_DELAY_MS))
+
+/** Сообщество/канал площадки, от имени которого будут публиковаться посты */
+export interface ConnectTarget {
+  id: string
+  label: string
+}
+
+/** Мок-каталог доступных целей публикации по площадкам (как будто пришёл из «OAuth»-ответа) */
+const MOCK_TARGETS: Record<string, ConnectTarget[]> = {
+  vk: [
+    { id: 'vk-1', label: 'Сообщество «Отложка»' },
+    { id: 'vk-2', label: 'Сообщество «Кофейня у дома»' },
+    { id: 'vk-3', label: 'Личная страница' },
+  ],
+  tg: [
+    { id: 'tg-1', label: 'Канал @otlozhka' },
+    { id: 'tg-2', label: 'Канал @coffee_dom' },
+  ],
+  ok: [
+    { id: 'ok-1', label: 'Группа «Отложка»' },
+    { id: 'ok-2', label: 'Группа «Кофейня у дома»' },
+  ],
+  max: [
+    { id: 'max-1', label: 'Канал «Отложка»' },
+    { id: 'max-2', label: 'Канал «Кофейня у дома»' },
+  ],
+  dzen: [
+    { id: 'dzen-1', label: 'Канал «Отложка»' },
+    { id: 'dzen-2', label: 'Канал «Истории кофейни»' },
+  ],
+  rutube: [
+    { id: 'rutube-1', label: 'Канал «Отложка»' },
+    { id: 'rutube-2', label: 'Канал «Кофейня у дома»' },
+  ],
+  youtube: [
+    { id: 'youtube-1', label: 'Канал «Отложка»' },
+    { id: 'youtube-2', label: 'Канал «Кофейня у дома»' },
+  ],
+}
+
+/**
+ * Мок «OAuth»-авторизации на стороне площадки: в ответ отдаёт список доступных
+ * сообществ/каналов. Номер попытки нужен для триггера ошибки (см. константу выше).
+ */
+export async function mockAuthorize(networkId: string, attempt: number): Promise<ConnectTarget[]> {
+  await wait()
+  if (networkId === MOCK_AUTH_ERROR_NETWORK_ID && attempt === 1) {
+    throw new Error('Площадка не ответила на запрос авторизации. Попробуйте ещё раз.')
+  }
+  return MOCK_TARGETS[networkId] ?? []
+}
+
+/** Мок записи выбранной цели публикаций в подключение */
+export async function mockConfirmTarget(): Promise<void> {
+  await wait()
+}
+
+/** Мок отключения площадки */
+export async function mockDisconnect(): Promise<void> {
+  await wait()
+}
+
+/** Достаём текст ошибки из мок-запроса (на будущее — из ответа API) */
+export function getConnectErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'Что-то пошло не так. Попробуйте ещё раз.'
+}

--- a/frontend/src/features/connect-platform/ui/ConnectPlatformModal.tsx
+++ b/frontend/src/features/connect-platform/ui/ConnectPlatformModal.tsx
@@ -1,22 +1,67 @@
-import { useState } from 'react'
-import { Button, Divider, Group, Modal, Stack, Text } from '@mantine/core'
+import { useRef, useState } from 'react'
+import {
+  ActionIcon,
+  Alert,
+  Box,
+  Button,
+  CloseButton,
+  Divider,
+  Group,
+  Modal,
+  Radio,
+  Stack,
+  Text,
+} from '@mantine/core'
+import { IconAlertCircle, IconArrowLeft } from '@tabler/icons-react'
 import { notifications } from '@mantine/notifications'
+import { useQueryClient } from '@tanstack/react-query'
+import type { QueryClient } from '@tanstack/react-query'
 import { NETWORKS } from '@/shared/config'
-import { ConfirmDeleteButton, NetworkPill } from '@/shared/ui'
-import { useConnections } from '@/entities/platform-account'
+import type { Network } from '@/shared/config'
+import { NetworkPill } from '@/shared/ui'
+import { connectionKeys, useConnections } from '@/entities/platform-account'
 import type { Connection } from '@/entities/platform-account'
+import {
+  getConnectErrorMessage,
+  mockAuthorize,
+  mockConfirmTarget,
+  mockDisconnect,
+} from '../api/mockConnectApi'
+import type { ConnectTarget } from '../api/mockConnectApi'
+
+// Тона текста из макета app-dashboard, блок data-screen-label="Подключение площадки"
+const TEXT_BODY = 'rgba(23,21,15,.65)'
+const TEXT_STEP = 'rgba(23,21,15,.6)'
+const TEXT_HINT = 'rgba(23,21,15,.45)'
+/** Красный деструктивной кнопки «Отключить» — из макета */
+const DANGER_COLOR = '#C4352D'
+
+// Full-width кнопки действия по макету: padding 13px, скругление 11
+const ACTION_BUTTON_STYLES = {
+  root: { height: 'auto', paddingBlock: 13, borderRadius: 11, fontSize: 14, fontWeight: 700 },
+} as const
+
+/** Шаги подключения — дословно из макета */
+const CONNECT_STEPS = [
+  'Авторизуетесь на стороне площадки — пароль нам не передаётся',
+  'Выбираете сообщество или канал для публикаций',
+  'Готово — площадка появится в календаре',
+]
 
 interface ConnectPlatformModalProps {
   opened: boolean
+  /** Площадка, для которой открыта модалка; null — общий список всех площадок */
+  networkId: string | null
   onClose: () => void
 }
 
 /**
- * Глобальная модалка подключения площадок. Состояние открытия приходит пропсами
- * от хоста модалок (widgets/app-shell); список подключений держим в ЛОКАЛЬНОМ
- * стейте, засеянном из useConnections(). Все мутации — заглушки (демо).
+ * Глобальная модалка подключения площадок. Состояние открытия и networkId приходят
+ * пропсами от хоста модалок (widgets/app-shell). С networkId — модалка одной площадки
+ * (режим подключения или отключения), без — общий список всех 7 площадок.
+ * Всё per-open состояние живёт в детях: Mantine размонтирует их при закрытии.
  */
-export function ConnectPlatformModal({ opened, onClose }: ConnectPlatformModalProps) {
+export function ConnectPlatformModal({ opened, networkId, onClose }: ConnectPlatformModalProps) {
   return (
     <Modal
       opened={opened}
@@ -24,82 +69,356 @@ export function ConnectPlatformModal({ opened, onClose }: ConnectPlatformModalPr
       centered
       radius="lg"
       size="md"
-      title="Подключение площадок"
+      padding={24}
+      withCloseButton={false}
     >
-      <ConnectPlatformList />
+      <ConnectPlatformContent initialNetworkId={networkId} onClose={onClose} />
     </Modal>
   )
 }
 
+interface ConnectPlatformContentProps {
+  initialNetworkId: string | null
+  onClose: () => void
+}
+
 /**
- * Список площадок с локальным стейтом. Живёт в детях модалки: Mantine размонтирует
- * их при закрытии, так что на каждое открытие стейт заново засевается из useConnections().
+ * Содержимое модалки: либо панель конкретной площадки, либо общий список,
+ * из которого можно провалиться в панель (со стрелкой «назад»).
  */
-function ConnectPlatformList() {
-  const { data } = useConnections()
+function ConnectPlatformContent({ initialNetworkId, onClose }: ConnectPlatformContentProps) {
+  const { data: connections } = useConnections()
+  const [activeId, setActiveId] = useState<string | null>(initialNetworkId)
 
-  const [connections, setConnections] = useState<Connection[]>(data)
+  const network = NETWORKS.find((n) => n.id === activeId)
 
+  if (!network) {
+    return <NetworkList connections={connections} onPick={setActiveId} onClose={onClose} />
+  }
+
+  const connection = connections.find((c) => c.networkId === network.id)
+
+  return (
+    <PlatformPanel
+      // Смена площадки полностью сбрасывает состояние панели
+      key={network.id}
+      network={network}
+      connected={connection?.connected ?? false}
+      onBack={initialNetworkId === null ? () => setActiveId(null) : undefined}
+      onClose={onClose}
+    />
+  )
+}
+
+interface NetworkListProps {
+  connections: Connection[]
+  onPick: (networkId: string) => void
+  onClose: () => void
+}
+
+/** Общий список всех площадок: кнопка в строке открывает панель подключения/отключения. */
+function NetworkList({ connections, onPick, onClose }: NetworkListProps) {
   const byId = new Map(connections.map((c) => [c.networkId, c]))
-
-  const connect = (networkId: string, name: string) => {
-    // TODO (Design First, backlog #118): POST /projects/{id}/connections (OAuth redirect).
-    setConnections((prev) =>
-      prev.map((c) =>
-        c.networkId === networkId ? { ...c, connected: true, account: `Аккаунт «${name}»` } : c,
-      ),
-    )
-    notifications.show({ color: 'green', message: `Площадка «${name}» подключена — OAuth (демо)` })
-  }
-
-  const disconnect = (networkId: string, name: string) => {
-    // TODO (Design First, backlog #118): DELETE /projects/{id}/connections/{networkId}.
-    setConnections((prev) =>
-      prev.map((c) =>
-        c.networkId === networkId ? { ...c, connected: false, account: undefined } : c,
-      ),
-    )
-    notifications.show({ color: 'green', message: `Площадка «${name}» отключена (демо)` })
-  }
 
   return (
     <Stack gap={0}>
-      {NETWORKS.map((network, index) => {
-        const conn = byId.get(network.id)
-        const connected = conn?.connected ?? false
+      <ModalHeader title="Подключение площадок" onClose={onClose} />
 
-        return (
-          <div key={network.id}>
-            {index > 0 && <Divider my="sm" />}
-            <Group justify="space-between" wrap="nowrap" gap="sm">
-              <Stack gap={4} style={{ minWidth: 0 }}>
-                <NetworkPill network={network} />
-                {connected && conn?.account && (
-                  <Text size="xs" c="dimmed" style={{ paddingLeft: 6 }}>
-                    {conn.account}
-                  </Text>
-                )}
-              </Stack>
+      <Stack gap={0} mt="sm">
+        {NETWORKS.map((network, index) => {
+          const conn = byId.get(network.id)
+          const connected = conn?.connected ?? false
 
-              {connected ? (
-                <ConfirmDeleteButton
-                  onConfirm={() => disconnect(network.id, network.name)}
-                  tooltip="Отключить"
-                  confirmText={`Отключить «${network.name}»? Публикации остановятся. Запланированные посты останутся в календаре и выйдут после повторного подключения.`}
-                />
-              ) : (
-                <Button variant="light" size="xs" onClick={() => connect(network.id, network.name)}>
-                  Подключить
+          return (
+            <div key={network.id}>
+              {index > 0 && <Divider my="sm" />}
+              <Group justify="space-between" wrap="nowrap" gap="sm">
+                <Stack gap={4} style={{ minWidth: 0 }}>
+                  <NetworkPill network={network} />
+                  {connected && conn?.account && (
+                    <Text size="xs" c="dimmed" style={{ paddingLeft: 6 }}>
+                      {conn.account}
+                    </Text>
+                  )}
+                </Stack>
+
+                <Button
+                  variant="light"
+                  color={connected ? 'red' : 'brand'}
+                  size="xs"
+                  onClick={() => onPick(network.id)}
+                >
+                  {connected ? 'Отключить' : 'Подключить'}
                 </Button>
-              )}
-            </Group>
-          </div>
-        )
-      })}
+              </Group>
+            </div>
+          )
+        })}
+      </Stack>
 
-      <Text ta="center" size="xs" c="dimmed" mt="lg">
-        Демо: подключение сработает мгновенно
-      </Text>
+      <DemoHint />
     </Stack>
+  )
+}
+
+interface PlatformPanelProps {
+  network: Network
+  connected: boolean
+  /** Возврат к общему списку — есть только если панель открыта из него */
+  onBack?: () => void
+  onClose: () => void
+}
+
+/**
+ * Панель одной площадки. Режим фиксируется на момент открытия:
+ * не подключена → шаги подключения, «OAuth» и выбор сообщества/канала;
+ * подключена → предупреждение и красная кнопка отключения.
+ */
+function PlatformPanel({ network, connected, onBack, onClose }: PlatformPanelProps) {
+  const queryClient = useQueryClient()
+
+  // Режим не меняем на лету, чтобы панель не «перещёлкивалась» после мутации мок-кэша
+  const [mode] = useState<'connect' | 'disconnect'>(connected ? 'disconnect' : 'connect')
+  const [step, setStep] = useState<'intro' | 'choose'>('intro')
+  const [targets, setTargets] = useState<ConnectTarget[]>([])
+  const [targetId, setTargetId] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  // Счётчик попыток «OAuth» — нужен мок-триггеру ошибки (повторная попытка успешна)
+  const attemptRef = useRef(0)
+
+  // «OAuth»-авторизация: по успеху получаем список сообществ/каналов и шаг выбора
+  const runAuthorize = async () => {
+    setLoading(true)
+    setError(null)
+    attemptRef.current += 1
+    try {
+      const available = await mockAuthorize(network.id, attemptRef.current)
+      setTargets(available)
+      setStep('choose')
+    } catch (err) {
+      setError(getConnectErrorMessage(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  // Подтверждение выбранной цели: записываем её в мок-подключение и закрываем модалку
+  const runConfirm = async () => {
+    const target = targets.find((t) => t.id === targetId)
+    if (!target) return
+    setLoading(true)
+    setError(null)
+    try {
+      await mockConfirmTarget()
+      updateConnection(queryClient, network.id, target.label)
+      notifications.show({
+        color: 'green',
+        message: `Площадка «${network.name}» подключена: ${target.label}`,
+      })
+      onClose()
+    } catch (err) {
+      setError(getConnectErrorMessage(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  // Отключение площадки в моке и закрытие модалки
+  const runDisconnect = async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      await mockDisconnect()
+      updateConnection(queryClient, network.id, undefined)
+      notifications.show({
+        color: 'green',
+        message: `Площадка «${network.name}» отключена — посты остались в календаре`,
+      })
+      onClose()
+    } catch (err) {
+      setError(getConnectErrorMessage(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const title = mode === 'disconnect' ? `Отключить ${network.name}?` : `Подключить ${network.name}`
+
+  return (
+    <Stack gap={0}>
+      <ModalHeader
+        network={network}
+        title={title}
+        onBack={loading ? undefined : onBack}
+        onClose={onClose}
+      />
+
+      {mode === 'connect' && step === 'intro' && (
+        <>
+          <Text mt={14} fz={13.5} lh={1.6} c={TEXT_BODY}>
+            Отложка получит право публиковать контент от имени вашего сообщества — через официальный
+            API площадки.
+          </Text>
+          <Stack mt={14} gap={8}>
+            {CONNECT_STEPS.map((text, index) => (
+              <Group key={text} gap={9} wrap="nowrap" align="flex-start">
+                <Text fz={12.5} fw={700} c="var(--mantine-color-success-7)">
+                  {index + 1}.
+                </Text>
+                <Text fz={12.5} c={TEXT_STEP}>
+                  {text}
+                </Text>
+              </Group>
+            ))}
+          </Stack>
+          <Button
+            fullWidth
+            mt={18}
+            color={network.color}
+            loading={loading}
+            styles={ACTION_BUTTON_STYLES}
+            onClick={runAuthorize}
+          >
+            Авторизоваться в «{network.name}»
+          </Button>
+        </>
+      )}
+
+      {mode === 'connect' && step === 'choose' && (
+        <>
+          <Text mt={14} fz={13.5} lh={1.6} c={TEXT_BODY}>
+            Авторизация прошла успешно. Выберите сообщество или канал — Отложка будет публиковать
+            посты от его имени.
+          </Text>
+          <Radio.Group value={targetId ?? ''} onChange={setTargetId} mt={14}>
+            <Stack gap={8}>
+              {targets.map((target) => (
+                <Radio
+                  key={target.id}
+                  value={target.id}
+                  label={target.label}
+                  size="sm"
+                  color={network.color}
+                  disabled={loading}
+                />
+              ))}
+            </Stack>
+          </Radio.Group>
+          <Button
+            fullWidth
+            mt={18}
+            color={network.color}
+            disabled={targetId === null}
+            loading={loading}
+            styles={ACTION_BUTTON_STYLES}
+            onClick={runConfirm}
+          >
+            Подключить
+          </Button>
+        </>
+      )}
+
+      {mode === 'disconnect' && (
+        <>
+          <Text mt={14} fz={13.5} lh={1.6} c={TEXT_BODY}>
+            Публикации в «{network.name}» остановятся. Запланированные посты останутся в календаре и
+            выйдут после повторного подключения.
+          </Text>
+          <Button
+            fullWidth
+            mt={18}
+            color={DANGER_COLOR}
+            loading={loading}
+            styles={ACTION_BUTTON_STYLES}
+            onClick={runDisconnect}
+          >
+            Отключить «{network.name}»
+          </Button>
+        </>
+      )}
+
+      {error && (
+        <Alert mt={14} color="red" variant="light" radius="md" icon={<IconAlertCircle size={16} />}>
+          {error}
+        </Alert>
+      )}
+
+      <DemoHint />
+    </Stack>
+  )
+}
+
+interface ModalHeaderProps {
+  /** Площадка для цветного значка 38×38; без неё — заголовок общего списка */
+  network?: Network
+  title: string
+  onBack?: () => void
+  onClose: () => void
+}
+
+/** Шапка модалки по макету: значок площадки, заголовок и круглый крестик справа. */
+function ModalHeader({ network, title, onBack, onClose }: ModalHeaderProps) {
+  return (
+    <Group gap={10} wrap="nowrap">
+      {onBack && (
+        <ActionIcon
+          variant="subtle"
+          color="gray"
+          radius="pill"
+          size={30}
+          onClick={onBack}
+          title="Назад к списку площадок"
+          aria-label="Назад к списку площадок"
+        >
+          <IconArrowLeft size={16} />
+        </ActionIcon>
+      )}
+      {network && (
+        <Box
+          style={{
+            width: 38,
+            height: 38,
+            borderRadius: 11,
+            background: network.color,
+            color: '#fff',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontSize: 12,
+            fontWeight: 800,
+            flexShrink: 0,
+          }}
+        >
+          {network.code}
+        </Box>
+      )}
+      <Text fz={17} fw={800} style={{ letterSpacing: -0.2 }}>
+        {title}
+      </Text>
+      <CloseButton ml="auto" radius="pill" size={30} onClick={onClose} aria-label="Закрыть" />
+    </Group>
+  )
+}
+
+/** Подпись-дисклеймер внизу модалки — дословно из макета */
+function DemoHint() {
+  return (
+    <Text ta="center" fz={11.5} c={TEXT_HINT} mt={10}>
+      Демо: подключение сработает мгновенно
+    </Text>
+  )
+}
+
+/**
+ * Обновляем мок-хранилище подключений (кэш TanStack Query): account задан — площадка
+ * подключена к этой цели, undefined — отключена. Чипсы календаря перерисуются сами.
+ * TODO (Design First, backlog #118): заменить на POST/DELETE /projects/{id}/connections.
+ */
+function updateConnection(queryClient: QueryClient, networkId: string, account?: string) {
+  queryClient.setQueryData<Connection[]>(connectionKeys.all, (prev) =>
+    prev?.map((c) =>
+      c.networkId === networkId ? { ...c, connected: account !== undefined, account } : c,
+    ),
   )
 }

--- a/frontend/src/pages/content-plan/ui/PlatformChips.tsx
+++ b/frontend/src/pages/content-plan/ui/PlatformChips.tsx
@@ -15,8 +15,8 @@ const BORDER_DISCONNECTED = 'rgba(23,21,15,.25)'
 
 /**
  * Ряд из 7 чипсов-площадок над календарём: показывает статус подключения,
- * по клику открывает модалку «Подключение площадок», а иконка-глаз в чипсе
- * включает/выключает площадку в фильтре постов календаря.
+ * по клику открывает модалку подключения кликнутой площадки, а иконка-глаз
+ * в чипсе включает/выключает площадку в фильтре постов календаря.
  */
 export function PlatformChips() {
   const { data: connections, isLoading, isError } = useConnections()
@@ -52,7 +52,7 @@ export function PlatformChips() {
           network={network}
           connected={connectedById.get(network.id) ?? false}
           filterActive={isNetworkActive(network.id)}
-          onOpen={() => openConnectPlatform()}
+          onOpen={() => openConnectPlatform(network.id)}
           onToggleFilter={() => toggleNetwork(network.id)}
         />
       ))}

--- a/frontend/src/pages/settings/ui/SettingsPage.tsx
+++ b/frontend/src/pages/settings/ui/SettingsPage.tsx
@@ -1,13 +1,14 @@
 import { useState } from 'react'
 import {
   Button,
+  Checkbox,
   ColorSwatch,
   Group,
   Paper,
   Popover,
   Select,
+  SimpleGrid,
   Stack,
-  Switch,
   Text,
   TextInput,
   Title,
@@ -19,11 +20,12 @@ import { PROJECT_COLORS } from '@/shared/config'
 import { ColorPickerModal } from '@/shared/ui'
 import { useCurrentProject } from '@/entities/project'
 
+// Часовые пояса публикаций: значение — IANA-идентификатор, подпись — как в макете
 const TIMEZONES = [
-  'Europe/Moscow (UTC+3)',
-  'Asia/Yekaterinburg (UTC+5)',
-  'Asia/Novosibirsk (UTC+7)',
-  'Asia/Vladivostok (UTC+10)',
+  { value: 'Europe/Moscow', label: 'Москва (UTC+3)' },
+  { value: 'Asia/Yekaterinburg', label: 'Екатеринбург (UTC+5)' },
+  { value: 'Asia/Novosibirsk', label: 'Новосибирск (UTC+7)' },
+  { value: 'Asia/Vladivostok', label: 'Владивосток (UTC+10)' },
 ]
 
 /** Заглушка сохранения — реальный API появится в бэкенде (issue #118). */
@@ -32,14 +34,21 @@ function showSavedStub() {
   notifications.show({ color: 'green', message: 'Сохранено (демо)' })
 }
 
+/** Заглушка смены пароля — реальный поток появится вместе с бэкендом. */
+function handleChangePassword() {
+  // TODO (Design First): смена пароля — отдельная backend-задача. Пока ничего не отправляем.
+}
+
 export function SettingsPage() {
   const project = useCurrentProject()
 
   const [projectName, setProjectName] = useState(project?.name ?? '')
   const [projectColor, setProjectColor] = useState(project?.color ?? PROJECT_COLORS[0])
-  const [timezone, setTimezone] = useState<string | null>(TIMEZONES[0])
+  const [timezone, setTimezone] = useState<string | null>(TIMEZONES[0].value)
   const [telegramReport, setTelegramReport] = useState(true)
   const [failureEmails, setFailureEmails] = useState(false)
+  const [watermark, setWatermark] = useState(true)
+  const [utmLinks, setUtmLinks] = useState(true)
   const [archiveConfirmOpened, archiveConfirm] = useDisclosure(false)
   const [colorModalOpened, colorModal] = useDisclosure(false)
 
@@ -50,118 +59,144 @@ export function SettingsPage() {
   }
 
   return (
-    <Stack maw={720} gap="lg">
+    <Stack gap="lg">
       <Title order={2}>Настройки</Title>
 
-      {/* ===== Профиль ===== */}
-      <Paper withBorder radius="md" p="lg">
-        <Stack gap="md">
-          <Title order={4}>Профиль</Title>
-          <TextInput label="Имя" defaultValue="Мария" />
-          <TextInput label="Почта" type="email" defaultValue="maria@example.ru" />
-          <Group>
-            <Button onClick={showSavedStub}>Сохранить</Button>
-          </Group>
-        </Stack>
-      </Paper>
-
-      {/* ===== Проект ===== */}
-      <Paper withBorder radius="md" p="lg">
-        <Stack gap="md">
-          <Title order={4}>Проект</Title>
-          <TextInput
-            label="Название"
-            value={projectName}
-            onChange={(event) => setProjectName(event.currentTarget.value)}
-          />
-          <Stack gap="xs">
-            <Text size="sm" fw={600}>
-              Цвет проекта
-            </Text>
-            {/* Превью выбранного цвета + кнопка, открывающая модалку выбора */}
-            <Group gap={10}>
-              <ColorSwatch color={projectColor} size={32} />
-              <Button variant="default" size="sm" onClick={colorModal.open}>
-                Изменить цвет…
+      {/* Две колонки: «Профиль» слева, «Проект» справа; danger-зона — на всю ширину */}
+      <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md" style={{ alignItems: 'start' }}>
+        {/* ===== Профиль ===== */}
+        <Paper withBorder radius="md" p="lg">
+          <Stack gap="md">
+            <Title order={4}>Профиль</Title>
+            <TextInput label="Имя" defaultValue="Мария" />
+            <TextInput label="Почта" type="email" defaultValue="maria@otlozhka.ru" />
+            <Group>
+              <Button variant="default" onClick={handleChangePassword}>
+                Сменить пароль
               </Button>
             </Group>
-          </Stack>
-          <Select
-            label="Часовой пояс публикаций"
-            data={TIMEZONES}
-            value={timezone}
-            onChange={setTimezone}
-            allowDeselect={false}
-          />
-          <Switch
-            label="Отчёт о публикациях в Telegram"
-            checked={telegramReport}
-            onChange={(event) => setTelegramReport(event.currentTarget.checked)}
-          />
-          <Switch
-            label="Письма о сбоях публикации"
-            checked={failureEmails}
-            onChange={(event) => setFailureEmails(event.currentTarget.checked)}
-          />
-          <Group>
-            <Button onClick={showSavedStub}>Сохранить</Button>
-          </Group>
-        </Stack>
-      </Paper>
-
-      {/* ===== Архив проекта (danger zone) ===== */}
-      <Paper
-        withBorder
-        radius="md"
-        p="lg"
-        style={{
-          borderColor: 'var(--mantine-color-red-4)',
-          backgroundColor: 'var(--mantine-color-red-0)',
-        }}
-      >
-        <Group justify="space-between" align="flex-start" wrap="nowrap" gap="lg">
-          <Stack gap={4} style={{ minWidth: 0 }}>
-            <Text fw={700} c="red">
-              Архив проекта
-            </Text>
-            <Text size="sm" c="dimmed">
-              Проект скроется из списка, публикации остановятся. Посты и настройки сохранятся —
-              вернуть проект можно в любой момент из списка проектов.
-            </Text>
-          </Stack>
-          <Popover
-            opened={archiveConfirmOpened}
-            onChange={(o) => (o ? archiveConfirm.open() : archiveConfirm.close())}
-            withArrow
-            position="bottom-end"
-          >
-            <Popover.Target>
-              <Button
-                color="red"
-                variant="light"
-                leftSection={<IconArchive size={16} />}
-                onClick={archiveConfirm.open}
-                style={{ flex: 'none' }}
-              >
-                Архивировать проект
-              </Button>
-            </Popover.Target>
-            <Popover.Dropdown>
-              <Text size="sm" mb="xs">
-                Архивировать проект «{projectName || project?.name}»?
+            <Stack gap="xs">
+              <Text size="sm" fw={600} c="dimmed">
+                Уведомления
               </Text>
-              <Group justify="flex-end" gap="xs">
-                <Button size="xs" variant="default" onClick={archiveConfirm.close}>
-                  Отмена
-                </Button>
-                <Button size="xs" color="red" onClick={handleArchive}>
-                  Архивировать
+              <Checkbox
+                label="Отчёт о публикациях в Telegram"
+                checked={telegramReport}
+                onChange={(event) => setTelegramReport(event.currentTarget.checked)}
+              />
+              <Checkbox
+                label="Письма о сбоях публикации"
+                checked={failureEmails}
+                onChange={(event) => setFailureEmails(event.currentTarget.checked)}
+              />
+            </Stack>
+            <Group>
+              <Button onClick={showSavedStub}>Сохранить</Button>
+            </Group>
+          </Stack>
+        </Paper>
+
+        {/* ===== Проект ===== */}
+        <Paper withBorder radius="md" p="lg">
+          <Stack gap="md">
+            <Title order={4}>Проект</Title>
+            <TextInput
+              label="Название"
+              value={projectName}
+              onChange={(event) => setProjectName(event.currentTarget.value)}
+            />
+            <Stack gap="xs">
+              <Text size="sm" fw={600}>
+                Цвет проекта
+              </Text>
+              {/* Превью выбранного цвета + кнопка, открывающая модалку выбора */}
+              <Group gap={10}>
+                <ColorSwatch color={projectColor} size={32} />
+                <Button variant="default" size="sm" onClick={colorModal.open}>
+                  Изменить цвет…
                 </Button>
               </Group>
-            </Popover.Dropdown>
-          </Popover>
-        </Group>
-      </Paper>
+            </Stack>
+            <Select
+              label="Часовой пояс публикаций"
+              data={TIMEZONES}
+              value={timezone}
+              onChange={setTimezone}
+              allowDeselect={false}
+            />
+            <Stack gap="xs">
+              <Checkbox
+                label="Водяной знак на фото"
+                checked={watermark}
+                onChange={(event) => setWatermark(event.currentTarget.checked)}
+              />
+              <Checkbox
+                label="UTM-метки в ссылках"
+                checked={utmLinks}
+                onChange={(event) => setUtmLinks(event.currentTarget.checked)}
+              />
+            </Stack>
+            <Group>
+              <Button onClick={showSavedStub}>Сохранить</Button>
+            </Group>
+          </Stack>
+        </Paper>
+
+        {/* ===== Архив проекта (danger zone) — на всю ширину грида ===== */}
+        <Paper
+          withBorder
+          radius="md"
+          p="lg"
+          style={{
+            gridColumn: '1 / -1',
+            borderColor: 'var(--mantine-color-red-4)',
+            backgroundColor: 'var(--mantine-color-red-0)',
+          }}
+        >
+          <Group justify="space-between" align="flex-start" wrap="nowrap" gap="lg">
+            <Stack gap={4} style={{ minWidth: 0 }}>
+              <Text fw={700} c="red">
+                Архив проекта
+              </Text>
+              <Text size="sm" c="dimmed">
+                Проект скроется из списка, публикации остановятся. Посты и настройки сохранятся —
+                вернуть проект можно в любой момент из списка проектов.
+              </Text>
+            </Stack>
+            <Popover
+              opened={archiveConfirmOpened}
+              onChange={(o) => (o ? archiveConfirm.open() : archiveConfirm.close())}
+              withArrow
+              position="bottom-end"
+            >
+              <Popover.Target>
+                <Button
+                  color="red"
+                  variant="light"
+                  leftSection={<IconArchive size={16} />}
+                  onClick={archiveConfirm.open}
+                  style={{ flex: 'none' }}
+                >
+                  Архивировать проект
+                </Button>
+              </Popover.Target>
+              <Popover.Dropdown>
+                <Text size="sm" mb="xs">
+                  Архивировать проект «{projectName || project?.name}»?
+                </Text>
+                <Group justify="flex-end" gap="xs">
+                  <Button size="xs" variant="default" onClick={archiveConfirm.close}>
+                    Отмена
+                  </Button>
+                  <Button size="xs" color="red" onClick={handleArchive}>
+                    Архивировать
+                  </Button>
+                </Group>
+              </Popover.Dropdown>
+            </Popover>
+          </Group>
+        </Paper>
+      </SimpleGrid>
 
       {/* Модалка выбора цвета проекта — применяет цвет в локальном состоянии формы */}
       <ColorPickerModal

--- a/frontend/src/widgets/app-shell/ui/AppModals.tsx
+++ b/frontend/src/widgets/app-shell/ui/AppModals.tsx
@@ -18,7 +18,11 @@ export function AppModals() {
   return (
     <>
       <ComposerModal opened={composer.opened} postId={composer.postId} onClose={closeComposer} />
-      <ConnectPlatformModal opened={connectPlatform.opened} onClose={closeConnectPlatform} />
+      <ConnectPlatformModal
+        opened={connectPlatform.opened}
+        networkId={connectPlatform.networkId}
+        onClose={closeConnectPlatform}
+      />
       <UpgradePlanModal opened={upgrade.opened} onClose={closeUpgrade} />
     </>
   )


### PR DESCRIPTION
Closes #192

Стек: после PR #209-team-permissions.

- SimpleGrid 2 колонки (Профиль | Проект), danger-зона на всю ширину
- Профиль: «Сменить пароль», подзаголовок «Уведомления» с чекбоксами Telegram/сбои (перенесены из «Проекта»)
- Проект: чекбоксы «Водяной знак на фото» и «UTM-метки в ссылках»; таймзоны value/label — IANA + «Москва (UTC+3)» и др.; модалка цвета переиспользована

Проверено агентом вживую (скриншот совпал с макетом), в интеграционном смоуке — две карточки, уведомления, русская таймзона. lint/tsc/build чисто.