### PR TITLE
chore(frontend): devtools только в dev, пин генератора API

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,6 @@
     "@reduxjs/toolkit": "^2.5.0",
     "@tabler/icons-react": "^3.24.0",
     "@tanstack/react-query": "^5.62.0",
-    "@tanstack/react-query-devtools": "^5.62.0",
     "dayjs": "^1.11.13",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
@@ -33,7 +32,8 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@feature-sliced/steiger-plugin": "^0.6.0",
-    "@hey-api/openapi-ts": "^0.99.0",
+    "@hey-api/openapi-ts": "0.99.0",
+    "@tanstack/react-query-devtools": "^5.62.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.4",

--- a/frontend/src/app/providers/AppProviders.tsx
+++ b/frontend/src/app/providers/AppProviders.tsx
@@ -19,7 +19,9 @@ export function AppProviders({ children }: { children: ReactNode }) {
               вместо белого экрана показать дружелюбный фолбэк с перезагрузкой.
               Внутри MantineProvider — фолбэку нужны компоненты Mantine. */}
           <ErrorBoundary>{children}</ErrorBoundary>
-          <ReactQueryDevtools initialIsOpen={false} />
+          {/* Devtools только в dev: import.meta.env.DEV в prod-сборке становится
+              false, ветка отсекается и пакет не попадает в production-бандл. */}
+          {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
         </MantineProvider>
       </QueryClientProvider>
     </ReduxProvider>


### PR DESCRIPTION
Closes #216

Стек: после #214.

- ReactQueryDevtools в AppProviders под import.meta.env.DEV; пакет перенесён в devDependencies (tree-shake-ится из prod-бандла — проверено grep по dist/)
- @hey-api/openapi-ts запинен на точную 0.99.0

Примечание: главный пункт issue про untrack **корневого** /.env — вне зоны frontend/** (корневой .env всё ещё в git). Нужен отдельный коммит: git rm --cached .env + правило в корневом .gitignore. Отмечено как follow-up.

Проверено: lint/tsc/build.