### PR TITLE
feat(frontend): санитайзинг пользовательского контента (XSS-guardrail)

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -54,6 +54,17 @@ export default tseslint.config(
             'Сессию/токены не храним в sessionStorage (XSS). См. docs/adr/0001-fe-session-storage.md',
         },
       ],
+      // Запрет dangerouslySetInnerHTML на пользовательском контенте — защита от stored XSS (#239).
+      // Аналог react/no-danger без eslint-plugin-react (плагина нет в зависимостях): ловим JSX-атрибут
+      // через core-правило. Нужен HTML-рендер — только через sanitizeHtml из @/shared/lib.
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'JSXAttribute[name.name="dangerouslySetInnerHTML"]',
+          message:
+            'dangerouslySetInnerHTML запрещён (XSS): санитайзьте через sanitizeHtml из @/shared/lib или рендерите как текст (#239).',
+        },
+      ],
     },
   },
 )

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "@tabler/icons-react": "^3.24.0",
     "@tanstack/react-query": "^5.62.0",
     "dayjs": "^1.11.13",
+    "dompurify": "^3.4.11",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-redux": "^9.2.0",

--- a/frontend/src/shared/lib/index.ts
+++ b/frontend/src/shared/lib/index.ts
@@ -1,2 +1,2 @@
 export { formatDateTime, toIso } from './date'
-export { sanitizeUrl } from './sanitize'
+export { sanitizeHtml, sanitizeUrl } from './sanitize'

--- a/frontend/src/shared/lib/sanitize.ts
+++ b/frontend/src/shared/lib/sanitize.ts
@@ -1,5 +1,9 @@
+import DOMPurify from 'dompurify'
+
 // Санитайзинг пользовательского контента (#215/#239).
-// sanitizeUrl — allowlist схем для ссылок (нужен ExternalLink и HTML-санитайзеру).
+// Предупредительный guardrail: сейчас весь пользовательский текст рендерится как текст
+// (React экранирует), но как только появится RichText-HTML (#195) или HTML-предпросмотр
+// площадки (#183), sanitizeHtml должен стоять на границе рендера — до любого innerHTML.
 
 /** Схемы, которые разрешаем в ссылках. Всё остальное (javascript:/data:/vbscript:) режем. */
 const SAFE_SCHEMES = ['http:', 'https:', 'mailto:']
@@ -38,4 +42,42 @@ export function sanitizeUrl(rawUrl: unknown): string {
   }
 
   return SAFE_SCHEMES.includes(protocol) ? cleaned : ''
+}
+
+/** Теги, разрешённые в санитайзенном HTML пользовательского контента. */
+const ALLOWED_TAGS = ['b', 'i', 'em', 'strong', 'a', 'ul', 'ol', 'li', 'br', 'p']
+/** Атрибуты-белый список: только ссылочные, чтобы отсечь on*, style и прочее. */
+const ALLOWED_ATTR = ['href', 'target', 'rel']
+
+// Хук на границе очистки: прогоняем href через sanitizeUrl и навешиваем безопасный rel.
+// Регистрируется один раз при импорте модуля (DOMPurify — синглтон).
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+  if (node.tagName === 'A' && node.hasAttribute('href')) {
+    const safeHref = sanitizeUrl(node.getAttribute('href'))
+    if (safeHref === '') {
+      // Небезопасная схема — снимаем ссылку целиком, оставляя только текст
+      node.removeAttribute('href')
+      node.removeAttribute('target')
+      node.removeAttribute('rel')
+    } else {
+      node.setAttribute('href', safeHref)
+      node.setAttribute('target', '_blank')
+      node.setAttribute('rel', 'noopener noreferrer')
+    }
+  }
+})
+
+/**
+ * Очищает HTML пользовательского контента: оставляет только whitelist тегов/атрибутов,
+ * вырезает on*, style, <script>, <iframe> и небезопасные ссылки.
+ * Использовать ПЕРЕД любым рендером HTML из API/ввода (dangerouslySetInnerHTML запрещён линтером).
+ */
+export function sanitizeHtml(dirty: unknown): string {
+  if (typeof dirty !== 'string') return ''
+  return DOMPurify.sanitize(dirty, {
+    ALLOWED_TAGS,
+    ALLOWED_ATTR,
+    FORBID_TAGS: ['script', 'iframe', 'style'],
+    FORBID_ATTR: ['style'],
+  })
 }


### PR DESCRIPTION
Closes #239

Стек: после #215.

- shared/lib/sanitize.ts: sanitizeHtml на dompurify (whitelist b/i/em/strong/a/ul/ol/li/br/p; вырезание on*/style/script/iframe; href через sanitizeUrl + rel=noopener) и sanitizeUrl (allowlist http/https/mailto, блок обфускации)
- eslint.config.js: запрет dangerouslySetInnerHTML через no-restricted-syntax (eslint-plugin-react в проекте нет — эквивалент react/no-danger)
- dompurify добавлен в dependencies

Работа предупредительная: dangerouslySetInnerHTML в коде НЕТ (весь пользовательский текст рендерится как текст), util готов к использованию для будущего HTML-контента.

Проверено: 17 XSS/легит-кейсов sanitizeUrl + OWASP-набор для sanitizeHtml на реальном модуле (script/img onerror/iframe/svg onload/javascript: — вырезаны; легит-теги и безопасные ссылки сохранены); eslint-guard ловит dangerouslySetInnerHTML. Тест-раннера в проекте нет — при добавлении vitest перенести набор в unit-тест.