### PR TITLE
feat(frontend): композер — прикрепление медиа через AttachMediaModal

### DIFF
--- a/frontend/src/features/composer/model/attachMedia.ts
+++ b/frontend/src/features/composer/model/attachMedia.ts
@@ -1,0 +1,56 @@
+import {
+  MEDIA_MAX_PHOTO_SIZE,
+  MEDIA_MAX_VIDEO_SIZE,
+  MEDIA_PHOTO_ACCEPT,
+  MEDIA_VIDEO_ACCEPT,
+  MEDIA_PHOTO_FORMATS_LABEL,
+  MEDIA_VIDEO_FORMATS_LABEL,
+} from '@/entities/media'
+
+/**
+ * Настройки модалки прикрепления медиа — сегмент features/composer.
+ * Раньше жили в features/attach-media, но композер не может импортировать
+ * соседнюю фичу (границы FSD: фича из фичи запрещена steiger). Поэтому конфиг
+ * и сама модалка перенесены в композер и переиспользуют entities/media напрямую.
+ */
+
+/** Тип вложения поста, который открывает вызывающий блок композера. */
+export type AttachmentKind = 'photo' | 'video' | 'cover'
+
+interface AttachmentKindConfig {
+  /** Заголовок модалки. */
+  title: string
+  /** Подпись форматов под дроп-зоной. */
+  formatsLabel: string
+  /** MIME-типы для клиентской валидации. */
+  accept: string[]
+  /** Лимит размера файла в байтах. */
+  maxSize: number
+  /** Показывать ли блок «Или выберите из медиатеки» (только фото и обложка). */
+  withLibrary: boolean
+}
+
+/** Настройки модалки «Загрузка файла» по типу вложения — тексты из макета. */
+export const ATTACHMENT_KIND_CONFIG: Record<AttachmentKind, AttachmentKindConfig> = {
+  photo: {
+    title: 'Загрузить фото',
+    formatsLabel: MEDIA_PHOTO_FORMATS_LABEL,
+    accept: MEDIA_PHOTO_ACCEPT,
+    maxSize: MEDIA_MAX_PHOTO_SIZE,
+    withLibrary: true,
+  },
+  video: {
+    title: 'Загрузить видео',
+    formatsLabel: MEDIA_VIDEO_FORMATS_LABEL,
+    accept: MEDIA_VIDEO_ACCEPT,
+    maxSize: MEDIA_MAX_VIDEO_SIZE,
+    withLibrary: false,
+  },
+  cover: {
+    title: 'Загрузить обложку',
+    formatsLabel: MEDIA_PHOTO_FORMATS_LABEL,
+    accept: MEDIA_PHOTO_ACCEPT,
+    maxSize: MEDIA_MAX_PHOTO_SIZE,
+    withLibrary: true,
+  },
+}

--- a/frontend/src/features/composer/model/composerForm.ts
+++ b/frontend/src/features/composer/model/composerForm.ts
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs'
+import { MEDIA_MOCK } from '@/entities/media'
 import type { Post } from '@/entities/scheduled-post'
 
 /**
@@ -16,13 +17,15 @@ export type RepeatMode = 'none' | 'day' | 'week' | 'month'
 /** Значения формы композера. */
 export interface ComposerFormValues {
   kind: PostKind
-  /** HTML из RichText-заглушки (тип «Пост»). */
+  /** HTML из RichText-редактора (тип «Пост»). */
   text: string
-  /** Имена прикреплённых фото (мок, до 4). */
+  /** id прикреплённых фото из медиатеки (entities/media), до 4. */
   attachments: string[]
+  /** id видеофайла из медиатеки (тип «Видео»); пусто — не выбран. */
   videoFile: string
   videoTitle: string
   videoDescription: string
+  /** id обложки из медиатеки (тип «Видео»); пусто — не выбрана. */
   cover: string
   /** id выбранных площадок из NETWORKS. */
   networks: string[]
@@ -38,6 +41,12 @@ export const DAY_LABELS = ['Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб', 'Вс
 
 /** Видеоплощадки: для типа «Пост» заблокированы (доступны только для «Видео»). */
 export const VIDEO_NETWORK_IDS: readonly string[] = ['rutube', 'youtube']
+
+// id медиатеки по типам — для префилла формы существующего поста (у мок-поста
+// хранится только mediaCount, поэтому вложения восстанавливаем реальными id
+// библиотеки, чтобы плитки показывали имена/превью через useMedia).
+const PHOTO_LIBRARY_IDS = MEDIA_MOCK.filter((item) => item.kind === 'photo').map((item) => item.id)
+const VIDEO_LIBRARY_IDS = MEDIA_MOCK.filter((item) => item.kind === 'video').map((item) => item.id)
 
 export const REPEAT_OPTIONS: { value: RepeatMode; label: string }[] = [
   { value: 'none', label: 'Не повторять' },
@@ -102,10 +111,8 @@ export function makeValuesFromPost(post: Post): ComposerFormValues {
   return {
     kind: isVideo ? 'video' : 'post',
     text: isVideo ? '' : post.text,
-    attachments: isVideo
-      ? []
-      : Array.from({ length: post.mediaCount ?? 0 }, (_, i) => `фото ${i + 1}.jpg`),
-    videoFile: isVideo ? 'видео.mp4' : '',
+    attachments: isVideo ? [] : PHOTO_LIBRARY_IDS.slice(0, post.mediaCount ?? 0),
+    videoFile: isVideo ? (VIDEO_LIBRARY_IDS[0] ?? '') : '',
     videoTitle: isVideo ? post.title.replace(/^▶ /, '') : '',
     videoDescription: isVideo ? post.text : '',
     cover: '',

--- a/frontend/src/features/composer/ui/AttachMediaModal.module.css
+++ b/frontend/src/features/composer/ui/AttachMediaModal.module.css
@@ -1,0 +1,20 @@
+/* Плитка быстрого выбора из медиатеки — пунктирная, как в макете app-dashboard.html. */
+.libraryTile {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  aspect-ratio: 4 / 3;
+  border: 1.5px dashed rgba(23, 21, 15, 0.2);
+  border-radius: 9px;
+  background: #f6f4ef;
+  color: rgba(23, 21, 15, 0.5);
+  text-align: center;
+  transition:
+    border-color 120ms ease,
+    color 120ms ease;
+}
+
+.libraryTile:hover {
+  border-color: var(--mantine-color-brand-6);
+  color: var(--mantine-color-brand-6);
+}

--- a/frontend/src/features/composer/ui/AttachMediaModal.tsx
+++ b/frontend/src/features/composer/ui/AttachMediaModal.tsx
@@ -1,0 +1,102 @@
+import { Modal, SimpleGrid, Text, UnstyledButton } from '@mantine/core'
+import { notifications } from '@mantine/notifications'
+import type { FileRejection } from '@mantine/dropzone'
+import { UploadDropzone, useMedia, useUploadMediaMutation } from '@/entities/media'
+import { ATTACHMENT_KIND_CONFIG } from '../model/attachMedia'
+import type { AttachmentKind } from '../model/attachMedia'
+import classes from './AttachMediaModal.module.css'
+
+interface AttachMediaModalProps {
+  opened: boolean
+  /** Тип вложения от вызывающего блока композера: фото / видео / обложка. */
+  kind: AttachmentKind
+  onClose: () => void
+  /**
+   * Итог выбора — id медиа: существующего из медиатеки или только что
+   * загруженного. Модалка про пост ничего не знает, прикрепление — на композере.
+   */
+  onSelect: (mediaId: string) => void
+}
+
+/**
+ * Модалка «Загрузка файла» — сегмент features/composer (перенесена из бывшей
+ * features/attach-media, чтобы не импортировать фичу из фичи). Дроп-зона с
+ * валидацией по типу вложения и, для фото/обложки, быстрый выбор из первых
+ * четырёх фото медиатеки. Загруженный файл тоже попадает в медиатеку
+ * (entities/media, мок-уровень), а наружу в обоих случаях уходит mediaId.
+ */
+export function AttachMediaModal({ opened, kind, onClose, onSelect }: AttachMediaModalProps) {
+  const config = ATTACHMENT_KIND_CONFIG[kind]
+  const upload = useUploadMediaMutation()
+  const { data } = useMedia()
+  // Первые 4 фото медиатеки — плитки быстрого выбора, как в макете.
+  const libraryPhotos = (data ?? []).filter((item) => item.kind === 'photo').slice(0, 4)
+
+  const pick = (mediaId: string) => {
+    onSelect(mediaId)
+    onClose()
+  }
+
+  // Файл сперва «загружается» в медиатеку, затем его id уходит вызывающему.
+  // mutateAsync вместо mutate: колбэки mutate() при повторных вызовах одного
+  // useMutation перекрывают друг друга (см. MediaUploadModal).
+  const handleDrop = (files: File[]) => {
+    const file = files[0]
+    if (!file) return
+    void upload.mutateAsync(file).then(({ item }) => pick(item.id))
+  }
+
+  // Клиентская валидация не прошла (тип или размер) — объясняем, что подходит.
+  const handleReject = (rejections: FileRejection[]) => {
+    const names = rejections.map((rejection) => rejection.file.name).join(', ')
+    notifications.show({
+      color: 'red',
+      message: `Файл не подходит: ${names}. Допустимы ${config.formatsLabel}.`,
+    })
+  }
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      title={config.title}
+      radius="lg"
+      centered
+      size={460}
+      styles={{ title: { fontWeight: 800, fontSize: 17, letterSpacing: '-.2px' } }}
+    >
+      <UploadDropzone
+        accept={config.accept}
+        maxSize={config.maxSize}
+        title="Перетащите файл сюда"
+        hint={`или нажмите, чтобы выбрать с компьютера · ${config.formatsLabel}`}
+        loading={upload.isPending}
+        onDrop={handleDrop}
+        onReject={handleReject}
+      />
+
+      {/* Для фото и обложки — быстрый выбор из существующих фото медиатеки */}
+      {config.withLibrary && libraryPhotos.length > 0 ? (
+        <>
+          <Text mt={14} fz={12.5} fw={600} style={{ color: 'rgba(23,21,15,.6)' }}>
+            Или выберите из медиатеки
+          </Text>
+          <SimpleGrid cols={4} spacing={8} mt={8}>
+            {libraryPhotos.map((photo) => (
+              <UnstyledButton
+                key={photo.id}
+                className={classes.libraryTile}
+                title={photo.name}
+                onClick={() => pick(photo.id)}
+              >
+                <Text component="span" fz={10.5} c="inherit" lineClamp={2} px={4}>
+                  {photo.name}
+                </Text>
+              </UnstyledButton>
+            ))}
+          </SimpleGrid>
+        </>
+      ) : null}
+    </Modal>
+  )
+}

--- a/frontend/src/features/composer/ui/ComposerModal.tsx
+++ b/frontend/src/features/composer/ui/ComposerModal.tsx
@@ -1,9 +1,8 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import {
   Box,
   Button,
   Chip,
-  FileButton,
   Group,
   Modal,
   Popover,
@@ -21,6 +20,7 @@ import { useForm } from '@mantine/form'
 import { notifications } from '@mantine/notifications'
 import { useQueryClient } from '@tanstack/react-query'
 import { IconChevronDown, IconSparkles } from '@tabler/icons-react'
+import { useMedia } from '@/entities/media'
 import { usePost } from '@/entities/scheduled-post'
 import { incrementAiUsage, useQuota } from '@/entities/subscription'
 import { NETWORKS } from '@/shared/config'
@@ -44,7 +44,9 @@ import {
   makeValuesFromPost,
 } from '../model/composerForm'
 import type { ComposerFormValues, PostKind, RepeatMode } from '../model/composerForm'
+import type { AttachmentKind } from '../model/attachMedia'
 import { AiAssistPanel } from './AiAssistPanel'
+import { AttachMediaModal } from './AttachMediaModal'
 import { RichTextArea } from './RichTextArea'
 
 /**
@@ -82,6 +84,15 @@ export function ComposerModal({ opened, postId, onClose }: ComposerModalProps) {
   const postsQuota = useQuota('posts')
   const postsBlocked = !isEditing && postsQuota.exhausted
   const [timeOpen, setTimeOpen] = useState(false)
+  // Какой тип вложения сейчас прикрепляем: открывает модалку загрузки; null — закрыта.
+  const [attachKind, setAttachKind] = useState<AttachmentKind | null>(null)
+
+  // Медиатека проекта — источник имён/превью прикреплённых вложений (по mediaId).
+  const { data: mediaData } = useMedia()
+  const mediaById = useMemo(
+    () => new Map((mediaData ?? []).map((item) => [item.id, item])),
+    [mediaData],
+  )
 
   const form = useForm<ComposerFormValues>({ initialValues: makeDefaultValues() })
 
@@ -106,6 +117,7 @@ export function ComposerModal({ opened, postId, onClose }: ComposerModalProps) {
     form.reset()
     // Локальное состояние сбрасываем при закрытии, чтобы следующее открытие было чистым
     setTimeOpen(false)
+    setAttachKind(null)
     onClose()
   }
 
@@ -121,9 +133,17 @@ export function ComposerModal({ opened, postId, onClose }: ComposerModalProps) {
     }
   }
 
-  const handleAddPhoto = (file: File | null) => {
-    if (!file || form.values.attachments.length >= 4) return
-    form.insertListItem('attachments', file.name)
+  // Итог модалки загрузки: mediaId прикрепляем в зависимости от типа вложения.
+  const handleAttachSelect = (mediaId: string) => {
+    if (attachKind === 'photo') {
+      if (form.values.attachments.length < 4 && !form.values.attachments.includes(mediaId)) {
+        form.insertListItem('attachments', mediaId)
+      }
+    } else if (attachKind === 'video') {
+      form.setFieldValue('videoFile', mediaId)
+    } else if (attachKind === 'cover') {
+      form.setFieldValue('cover', mediaId)
+    }
   }
 
   const handleAiDescription = () => {
@@ -197,53 +217,59 @@ export function ComposerModal({ opened, postId, onClose }: ComposerModalProps) {
                 onInsert={(text) => form.setFieldValue('text', text)}
               />
 
-              {/* Вложения-фото (мок): плитки с именами файлов, до 4 штук */}
+              {/* Вложения-фото: плитки-превью из медиатеки (по mediaId), до 4 штук */}
               <Box>
                 <Text fz="sm" fw={600} c="dimmed" mb={8}>
                   Фото
                 </Text>
                 <Group gap={8}>
-                  {form.values.attachments.map((name, index) => (
-                    <Tooltip key={`${name}-${index}`} label="Убрать фото">
-                      <UnstyledButton
-                        onClick={() => form.removeListItem('attachments', index)}
-                        style={{
-                          width: 64,
-                          height: 52,
-                          borderRadius: 9,
-                          background: TILE_BG,
-                          border: `1.5px dashed ${MUTED_DASH}`,
-                          fontSize: 10.5,
-                          color: 'var(--mantine-color-dimmed)',
-                          textAlign: 'center',
-                          overflow: 'hidden',
-                          padding: 2,
-                        }}
+                  {form.values.attachments.map((mediaId, index) => {
+                    const media = mediaById.get(mediaId)
+                    return (
+                      <Tooltip
+                        key={`${mediaId}-${index}`}
+                        label={`Убрать: ${media?.name ?? 'фото'}`}
                       >
-                        {name}
-                      </UnstyledButton>
-                    </Tooltip>
-                  ))}
-                  {form.values.attachments.length < 4 && (
-                    <FileButton onChange={handleAddPhoto} accept="image/png,image/jpeg,image/webp">
-                      {(props) => (
                         <UnstyledButton
-                          {...props}
+                          onClick={() => form.removeListItem('attachments', index)}
                           style={{
                             width: 64,
                             height: 52,
                             borderRadius: 9,
-                            border: '1.5px dashed var(--mantine-color-brand-3)',
-                            fontSize: 11,
-                            fontWeight: 600,
-                            color: 'var(--mantine-color-brand-6)',
+                            background: TILE_BG,
+                            border: `1.5px dashed ${MUTED_DASH}`,
+                            fontSize: 10.5,
+                            color: 'var(--mantine-color-dimmed)',
                             textAlign: 'center',
+                            overflow: 'hidden',
+                            padding: media?.url ? 0 : 2,
+                            // Превью медиатеки фоном плитки; без url — имя файла текстом.
+                            backgroundImage: media?.url ? `url("${media.url}")` : undefined,
+                            backgroundSize: 'cover',
+                            backgroundPosition: 'center',
                           }}
                         >
-                          + Фото
+                          {media?.url ? null : (media?.name ?? mediaId)}
                         </UnstyledButton>
-                      )}
-                    </FileButton>
+                      </Tooltip>
+                    )
+                  })}
+                  {form.values.attachments.length < 4 && (
+                    <UnstyledButton
+                      onClick={() => setAttachKind('photo')}
+                      style={{
+                        width: 64,
+                        height: 52,
+                        borderRadius: 9,
+                        border: '1.5px dashed var(--mantine-color-brand-3)',
+                        fontSize: 11,
+                        fontWeight: 600,
+                        color: 'var(--mantine-color-brand-6)',
+                        textAlign: 'center',
+                      }}
+                    >
+                      + Фото
+                    </UnstyledButton>
                   )}
                   <Text fz="xs" c="dimmed" style={{ alignSelf: 'center' }}>
                     до 4 фото
@@ -255,36 +281,29 @@ export function ComposerModal({ opened, postId, onClose }: ComposerModalProps) {
 
           {isVideo && (
             <>
-              {/* Зона загрузки видеофайла */}
-              <FileButton
-                onChange={(file) => file && form.setFieldValue('videoFile', file.name)}
-                accept="video/mp4,video/*"
+              {/* Зона загрузки видеофайла — открывает модалку прикрепления медиа */}
+              <UnstyledButton
+                onClick={() => setAttachKind('video')}
+                style={{
+                  width: '100%',
+                  border: `1.5px dashed ${
+                    form.values.videoFile ? 'var(--mantine-color-success-4)' : MUTED_DASH
+                  }`,
+                  borderRadius: 12,
+                  background: TILE_BG,
+                  padding: 18,
+                  textAlign: 'center',
+                  fontSize: 13,
+                  fontWeight: 600,
+                  color: form.values.videoFile
+                    ? 'var(--mantine-color-success-7)'
+                    : 'var(--mantine-color-dimmed)',
+                }}
               >
-                {(props) => (
-                  <UnstyledButton
-                    {...props}
-                    style={{
-                      width: '100%',
-                      border: `1.5px dashed ${
-                        form.values.videoFile ? 'var(--mantine-color-success-4)' : MUTED_DASH
-                      }`,
-                      borderRadius: 12,
-                      background: TILE_BG,
-                      padding: 18,
-                      textAlign: 'center',
-                      fontSize: 13,
-                      fontWeight: 600,
-                      color: form.values.videoFile
-                        ? 'var(--mantine-color-success-7)'
-                        : 'var(--mantine-color-dimmed)',
-                    }}
-                  >
-                    {form.values.videoFile
-                      ? `✓ ${form.values.videoFile} — нажмите, чтобы заменить`
-                      : 'Перетащите видео сюда или нажмите, чтобы выбрать · до 2 ГБ, MP4'}
-                  </UnstyledButton>
-                )}
-              </FileButton>
+                {form.values.videoFile
+                  ? `✓ ${mediaById.get(form.values.videoFile)?.name ?? 'видео'} — нажмите, чтобы заменить`
+                  : 'Нажмите, чтобы выбрать видео · до 2 ГБ, MP4'}
+              </UnstyledButton>
 
               <Box style={{ display: 'grid', gridTemplateColumns: 'minmax(0,1fr) 132px', gap: 14 }}>
                 <Stack gap="xs">
@@ -326,38 +345,33 @@ export function ComposerModal({ opened, postId, onClose }: ComposerModalProps) {
                   <Text fz="sm" fw={600} c="dimmed" mb={6}>
                     Обложка
                   </Text>
-                  <FileButton
-                    onChange={(file) => file && form.setFieldValue('cover', file.name)}
-                    accept="image/png,image/jpeg,image/webp"
+                  <UnstyledButton
+                    onClick={() => setAttachKind('cover')}
+                    style={{
+                      width: '100%',
+                      aspectRatio: '16/10',
+                      border: `1.5px dashed ${
+                        form.values.cover ? 'var(--mantine-color-success-4)' : MUTED_DASH
+                      }`,
+                      borderRadius: 10,
+                      background: TILE_BG,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      fontSize: 11,
+                      fontWeight: 600,
+                      textAlign: 'center',
+                      padding: 6,
+                      overflow: 'hidden',
+                      color: form.values.cover
+                        ? 'var(--mantine-color-success-7)'
+                        : 'var(--mantine-color-dimmed)',
+                    }}
                   >
-                    {(props) => (
-                      <UnstyledButton
-                        {...props}
-                        style={{
-                          width: '100%',
-                          aspectRatio: '16/10',
-                          border: `1.5px dashed ${
-                            form.values.cover ? 'var(--mantine-color-success-4)' : MUTED_DASH
-                          }`,
-                          borderRadius: 10,
-                          background: TILE_BG,
-                          display: 'flex',
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                          fontSize: 11,
-                          fontWeight: 600,
-                          textAlign: 'center',
-                          padding: 6,
-                          overflow: 'hidden',
-                          color: form.values.cover
-                            ? 'var(--mantine-color-success-7)'
-                            : 'var(--mantine-color-dimmed)',
-                        }}
-                      >
-                        {form.values.cover ? `✓ ${form.values.cover}` : '1280 × 720'}
-                      </UnstyledButton>
-                    )}
-                  </FileButton>
+                    {form.values.cover
+                      ? `✓ ${mediaById.get(form.values.cover)?.name ?? 'обложка'}`
+                      : '1280 × 720'}
+                  </UnstyledButton>
                 </Box>
               </Box>
             </>
@@ -560,6 +574,15 @@ export function ComposerModal({ opened, postId, onClose }: ComposerModalProps) {
           </Group>
         </Stack>
       </form>
+
+      {/* Модалка прикрепления медиа (сегмент композера): дроп-зона + выбор из
+          медиатеки; наружу отдаёт mediaId, который прикрепляем по attachKind. */}
+      <AttachMediaModal
+        opened={attachKind !== null}
+        kind={attachKind ?? 'photo'}
+        onClose={() => setAttachKind(null)}
+        onSelect={handleAttachSelect}
+      />
     </Modal>
   )
 }


### PR DESCRIPTION
Follow-up к #198 (медиа-загрузка, уже смержена) — подключение выбора медиа к композеру.

Стек: после #195-tiptap.

- Кнопка «+ Фото» и зоны видео/обложки открывают AttachMediaModal (kind photo/video/cover); onSelect(mediaId) прикрепляет
- Вложения переведены с имён файлов на mediaId (имя/превью из useMedia)
- **Граница FSD:** фича не может импортить соседнюю фичу (steiger) — AttachMediaModal перенесён СЕГМЕНТОМ в features/composer (переиспользует entities/media напрямую); старая features/attach-media осталась без импортёров (кандидат на удаление отдельным PR)

Проверено (headless Chrome): «+ Фото» открывает модалку «Загрузить фото» с Dropzone и выбором из медиатеки. lint/tsc/build чисто, steiger границы целы.