### PR TITLE
fix(frontend): демо контент-плана на лендинге — лимит добавлений + модалка регистрации

### DIFF
--- a/frontend/src/pages/landing/ui/sections/HeroSection.tsx
+++ b/frontend/src/pages/landing/ui/sections/HeroSection.tsx
@@ -61,6 +61,11 @@ const BORDER = 'rgba(23,21,15,.1)'
 const SOFT_BORDER = 'rgba(23,21,15,.09)'
 const WEEKEND_COLOR = '#C4552D'
 
+// Демо на лендинге даёт «пощупать» добавление постов, но ограниченно:
+// после MAX_DEMO_ADDS добавлений «+» открывает регистрацию — дальше уже в кабинете.
+const INITIAL_TOTAL = INITIAL_WEEK.reduce((sum, day) => sum + day.length, 0)
+const MAX_DEMO_ADDS = 3
+
 /** Плюрализация русских существительных: [1, 2-4, 5+]. */
 function plural(n: number, forms: [string, string, string]): string {
   const a = Math.abs(n) % 100
@@ -77,6 +82,12 @@ export function HeroSection() {
   const [nextSeed, setNextSeed] = useState(3)
 
   const addPost = (dayIdx: number) => {
+    // Демо расширяется лишь на пару постов; дальше зовём регистрацию.
+    const currentTotal = week.reduce((sum, day) => sum + day.length, 0)
+    if (currentTotal - INITIAL_TOTAL >= MAX_DEMO_ADDS) {
+      open('register')
+      return
+    }
     const seed = nextSeed
     setWeek((prev) => {
       const next = prev.map((day) => day.slice())


### PR DESCRIPTION
Демо-календарь в hero на главной теперь ограничивает добавление постов.

## Что изменилось
- «+» в демо-календаре добавляет максимум **3 поста** (сверх начальных) — можно «пощупать».
- Следующий клик «+» вместо добавления открывает модалку **регистрации/входа** (`useAuthModal.open('register')`) — дальнейшее планирование уже в кабинете.
- Удаление постов (клик по посту) уменьшает счётчик, так что лимит считается по чистому приросту.

## Проверено (headless Chrome)
Старт 8 постов → +1/+2/+3 добавляют (до 11) → 4-й клик «+» открывает модалку «Вход / Регистрация · Создайте аккаунт». lint (ESLint+steiger) / tsc — зелёные.
