### PR TITLE
feat(frontend): демо-воронка лендинга — 2-е нажатие «+» → выбор тарифа → регистрация

### DIFF
--- a/frontend/src/pages/landing/ui/PlanPickerModal.tsx
+++ b/frontend/src/pages/landing/ui/PlanPickerModal.tsx
@@ -1,0 +1,136 @@
+import { Badge, Button, Card, Group, Modal, SimpleGrid, Stack, Text } from '@mantine/core'
+import { IconCheck } from '@tabler/icons-react'
+
+const FEATURED_BORDER = '2px solid #2B50EC'
+const CHECK_COLOR = 'var(--mantine-color-success-6)'
+
+interface Plan {
+  name: string
+  price: string
+  priceSuffix?: string
+  note: string
+  features: string[]
+  featured?: boolean
+  badge?: string
+}
+
+// Компактный набор тарифов для «воронки» с демо-календаря — те же планы, что в тизере лендинга.
+const PLANS: Plan[] = [
+  {
+    name: 'Бесплатный',
+    price: '0 ₽',
+    note: 'навсегда',
+    features: ['3 соцсети', '10 постов в месяц'],
+  },
+  {
+    name: 'Старт',
+    price: '490 ₽',
+    priceSuffix: ' /мес',
+    note: '7 дней бесплатно',
+    features: ['7 соцсетей', 'посты без лимита', '50 ИИ-текстов в месяц'],
+    featured: true,
+    badge: 'Выбирают чаще',
+  },
+  {
+    name: 'Про',
+    price: '990 ₽',
+    priceSuffix: ' /мес',
+    note: '7 дней бесплатно',
+    features: ['5 проектов', 'команда из 3 человек', '200 ИИ-текстов'],
+  },
+]
+
+interface PlanPickerModalProps {
+  opened: boolean
+  onClose: () => void
+  /** Пользователь выбрал тариф — дальше воронка ведёт к регистрации. */
+  onChoose: (planName: string) => void
+}
+
+/**
+ * Лёгкая модалка выбора тарифа для лендинга: всплывает, когда в демо-календаре
+ * упёрлись в лимит добавлений. «Выбрать» по тарифу продолжает воронку регистрацией.
+ * Дамб-компонент: состояние открытия и переход к регистрации — на стороне HeroSection.
+ */
+export function PlanPickerModal({ opened, onClose, onChoose }: PlanPickerModalProps) {
+  return (
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      centered
+      radius="lg"
+      size="lg"
+      title={
+        <Stack gap={2}>
+          <Text fw={800} fz="lg">
+            Планируйте без ограничений
+          </Text>
+          <Text fz="sm" c="dimmed">
+            В демо можно добавить пару постов. Выберите тариф — и продолжим в личном кабинете.
+          </Text>
+        </Stack>
+      }
+    >
+      <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="sm" mt="xs">
+        {PLANS.map((plan) => (
+          <Card
+            key={plan.name}
+            withBorder
+            radius="lg"
+            padding="md"
+            style={{
+              position: 'relative',
+              border: plan.featured ? FEATURED_BORDER : undefined,
+            }}
+          >
+            <Stack gap={8} h="100%">
+              {plan.badge ? (
+                <Badge
+                  color="brand"
+                  radius="sm"
+                  style={{ position: 'absolute', top: -10, left: 14 }}
+                >
+                  {plan.badge}
+                </Badge>
+              ) : null}
+              <Text fw={700} fz="sm">
+                {plan.name}
+              </Text>
+              <Text fz={22} fw={800} style={{ letterSpacing: '-0.4px', lineHeight: 1 }}>
+                {plan.price}
+                {plan.priceSuffix ? (
+                  <Text component="span" fz={12} fw={600} c="dimmed">
+                    {plan.priceSuffix}
+                  </Text>
+                ) : null}
+              </Text>
+              <Text fz={11.5} c="dimmed">
+                {plan.note}
+              </Text>
+              <Stack gap={5} mt={4} mb={10}>
+                {plan.features.map((f) => (
+                  <Group key={f} gap={7} wrap="nowrap" align="flex-start">
+                    <IconCheck size={13} stroke={3} color={CHECK_COLOR} style={{ marginTop: 3 }} />
+                    <Text fz={12.5} lh={1.35}>
+                      {f}
+                    </Text>
+                  </Group>
+                ))}
+              </Stack>
+              <Button
+                mt="auto"
+                fullWidth
+                radius="md"
+                color="brand"
+                variant={plan.featured ? 'filled' : 'default'}
+                onClick={() => onChoose(plan.name)}
+              >
+                Выбрать
+              </Button>
+            </Stack>
+          </Card>
+        ))}
+      </SimpleGrid>
+    </Modal>
+  )
+}

--- a/frontend/src/pages/landing/ui/PlanPickerModal.tsx
+++ b/frontend/src/pages/landing/ui/PlanPickerModal.tsx
@@ -38,6 +38,13 @@ const PLANS: Plan[] = [
     note: '7 дней бесплатно',
     features: ['5 проектов', 'команда из 3 человек', '200 ИИ-текстов'],
   },
+  {
+    name: 'Агентство',
+    price: '2490 ₽',
+    priceSuffix: ' /мес',
+    note: 'для агентств и команд',
+    features: ['20 проектов', '10 пользователей', 'ИИ без лимита'],
+  },
 ]
 
 interface PlanPickerModalProps {
@@ -59,7 +66,7 @@ export function PlanPickerModal({ opened, onClose, onChoose }: PlanPickerModalPr
       onClose={onClose}
       centered
       radius="lg"
-      size="lg"
+      size={900}
       title={
         <Stack gap={2}>
           <Text fw={800} fz="lg">
@@ -71,7 +78,7 @@ export function PlanPickerModal({ opened, onClose, onChoose }: PlanPickerModalPr
         </Stack>
       }
     >
-      <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="sm" mt="xs">
+      <SimpleGrid cols={{ base: 1, xs: 2, md: 4 }} spacing="sm" mt="xs">
         {PLANS.map((plan) => (
           <Card
             key={plan.name}

--- a/frontend/src/pages/landing/ui/PlanPickerModal.tsx
+++ b/frontend/src/pages/landing/ui/PlanPickerModal.tsx
@@ -79,23 +79,22 @@ export function PlanPickerModal({ opened, onClose, onChoose }: PlanPickerModalPr
             radius="lg"
             padding="md"
             style={{
-              position: 'relative',
               border: plan.featured ? FEATURED_BORDER : undefined,
             }}
           >
             <Stack gap={8} h="100%">
-              {plan.badge ? (
-                <Badge
-                  color="brand"
-                  radius="sm"
-                  style={{ position: 'absolute', top: -10, left: 14 }}
-                >
-                  {plan.badge}
-                </Badge>
-              ) : null}
-              <Text fw={700} fz="sm">
-                {plan.name}
-              </Text>
+              {/* Бейдж — в потоке рядом с названием: без absolute/отрицательных сдвигов,
+                  чтобы не обрезался краем карточки/модалки. */}
+              <Group gap={8} wrap="nowrap" align="center" mih={22}>
+                <Text fw={700} fz="sm">
+                  {plan.name}
+                </Text>
+                {plan.badge ? (
+                  <Badge color="brand" radius="sm" size="xs" tt="none">
+                    {plan.badge}
+                  </Badge>
+                ) : null}
+              </Group>
               <Text fz={22} fw={800} style={{ letterSpacing: '-0.4px', lineHeight: 1 }}>
                 {plan.price}
                 {plan.priceSuffix ? (

--- a/frontend/src/pages/landing/ui/sections/HeroSection.tsx
+++ b/frontend/src/pages/landing/ui/sections/HeroSection.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useDisclosure } from '@mantine/hooks'
 import { Link } from 'react-router-dom'
 import {
   Badge,
@@ -16,6 +17,7 @@ import { IconPlus } from '@tabler/icons-react'
 import { NetworkPill } from '@/shared/ui'
 import { NETWORKS } from '@/shared/config'
 import { useAuthModal } from '@/features/auth'
+import { PlanPickerModal } from '../PlanPickerModal'
 
 interface CalendarPost {
   networkIdx: number
@@ -61,10 +63,10 @@ const BORDER = 'rgba(23,21,15,.1)'
 const SOFT_BORDER = 'rgba(23,21,15,.09)'
 const WEEKEND_COLOR = '#C4552D'
 
-// Демо на лендинге даёт «пощупать» добавление постов, но ограниченно:
-// после MAX_DEMO_ADDS добавлений «+» открывает регистрацию — дальше уже в кабинете.
+// Демо на лендинге даёт «пощупать» добавление постов, но ограниченно: первый «+»
+// добавляет пост, а на втором нажатии всплывает выбор тарифа (дальше — регистрация).
 const INITIAL_TOTAL = INITIAL_WEEK.reduce((sum, day) => sum + day.length, 0)
-const MAX_DEMO_ADDS = 3
+const MAX_DEMO_ADDS = 1
 
 /** Плюрализация русских существительных: [1, 2-4, 5+]. */
 function plural(n: number, forms: [string, string, string]): string {
@@ -78,14 +80,15 @@ function plural(n: number, forms: [string, string, string]): string {
 
 export function HeroSection() {
   const { open } = useAuthModal()
+  const [pickerOpened, picker] = useDisclosure(false)
   const [week, setWeek] = useState<CalendarPost[][]>(INITIAL_WEEK)
   const [nextSeed, setNextSeed] = useState(3)
 
   const addPost = (dayIdx: number) => {
-    // Демо расширяется лишь на пару постов; дальше зовём регистрацию.
+    // Первый «+» добавляет пост, на втором нажатии всплывает выбор тарифа.
     const currentTotal = week.reduce((sum, day) => sum + day.length, 0)
     if (currentTotal - INITIAL_TOTAL >= MAX_DEMO_ADDS) {
-      open('register')
+      picker.open()
       return
     }
     const seed = nextSeed
@@ -315,6 +318,16 @@ export function HeroSection() {
           </Box>
         </Stack>
       </Container>
+
+      {/* Воронка демо: выбор тарифа → регистрация. */}
+      <PlanPickerModal
+        opened={pickerOpened}
+        onClose={picker.close}
+        onChoose={() => {
+          picker.close()
+          open('register')
+        }}
+      />
     </Box>
   )
 }


### PR DESCRIPTION
Демо-календарь в hero на главной стал воронкой: попробовал → выбор тарифа → регистрация.

## Что изменилось
- Первый «+» в демо-календаре добавляет пост (как раньше), но лимит демо снижен до **1 добавления**.
- На **2-м нажатии** «+» вместо прямой формы регистрации всплывает **лёгкая модалка выбора тарифа** (`PlanPickerModal`, `pages/landing/ui`): 3 плана — Бесплатный / Старт (выделен) / Про, как в тизере тарифов.
- Клик **«Выбрать»** по любому тарифу продолжает воронку — открывает форму регистрации (`useAuthModal.open('register')`).

## Детали
- `PlanPickerModal` — «дамб»-компонент (props `opened/onClose/onChoose`); состояние и переход к регистрации — на стороне `HeroSection`, чтобы не импортировать фичу из фичи (границы FSD).
- Дальнейшие шаги воронки (онбординг/CJM после регистрации) — вне этого PR.

## Проверено (headless Chrome)
Старт 8 постов → 1-й «+» → 9 → 2-й «+» открывает «Планируйте без ограничений» с тарифами → «Выбрать» открывает форму регистрации. lint (ESLint+steiger) / tsc — зелёные, JS-ошибок нет.
