### PR TITLE
fix(frontend): тизер тарифов на лендинге — 4 тарифа (добавлен «Агентство»)

### DIFF
--- a/frontend/src/pages/landing/ui/sections/PricingTeaserSection.tsx
+++ b/frontend/src/pages/landing/ui/sections/PricingTeaserSection.tsx
@@ -42,6 +42,14 @@ const PLANS: Plan[] = [
     features: ['5 проектов · команда из 3 человек', '200 ИИ-текстов · согласование'],
     cta: 'Выбрать',
   },
+  {
+    name: 'Агентство',
+    price: '2490 ₽',
+    priceSuffix: ' /мес',
+    note: 'или 1992 ₽/мес при оплате за год',
+    features: ['20 проектов · команда из 10 человек', 'ИИ без лимита · отчёты для клиентов'],
+    cta: 'Написать нам',
+  },
 ]
 
 /** Тизер тарифов лендинга: три плана, рекомендованный выделен рамкой и бейджем. */
@@ -56,7 +64,7 @@ export function PricingTeaserSection() {
         </Anchor>
       </Group>
 
-      <SimpleGrid cols={{ base: 1, md: 3 }} spacing="lg" mt="md" verticalSpacing="lg">
+      <SimpleGrid cols={{ base: 1, sm: 2, md: 4 }} spacing="lg" mt="md" verticalSpacing="lg">
         {PLANS.map((plan) => (
           <Card
             key={plan.name}


### PR DESCRIPTION
На лендинге в секции «Тарифы · Простые и без звёздочек» было 3 тарифа, а должно 4 — добавлен **«Агентство» (2490 ₽/мес)**, как на /pricing, в модалке апгрейда и в PlanPickerModal.

Сетка: 4 колонки на десктопе (md), 2 на планшете (sm), стопкой на мобильном. Бейдж «Выбирают чаще всего» у «Старта» не обрезается, ссылка «Все тарифы и сравнение →» сохранена.

Проверено (headless Chrome): 4 карточки [Бесплатный, Старт, Про, Агентство], grid из 4 колонок; lint (ESLint+steiger) / tsc — зелёные.